### PR TITLE
Clarifie les journaux de recherche de médias

### DIFF
--- a/bin/offline_transcode.sh
+++ b/bin/offline_transcode.sh
@@ -123,7 +123,7 @@ for DIR in "${DIRS[@]}"; do
   fi
 
   FILES=()
-  log "Recherche de fichiers médias dans ${REL_DIR:-.}"
+  log "Recherche de fichiers médias dans ${REL_DIR:-.} (chemin complet: $DIR)"
   if ! mapfile -d '' -t FILES < <(find "$DIR" -maxdepth 1 -type f \
     \( -iname "*.mkv" -o -iname "*.mp4" -o -iname "*.vob" -o -iname "*.m2ts" \) -print0 2>>"$LOG" | sort -z); then
     status_files=("${PIPESTATUS[@]}")
@@ -132,7 +132,7 @@ for DIR in "${DIRS[@]}"; do
     continue
   fi
   status_files=("${PIPESTATUS[@]}")
-  log "Fichiers médias détectés dans ${REL_DIR:-.}: ${#FILES[@]} (PIPESTATUS=${status_files[*]})"
+  log "Fichiers médias détectés dans ${REL_DIR:-.}: ${#FILES[@]} (PIPESTATUS=${status_files[*]}, chemin complet: $DIR)"
 
   if (( ${#FILES[@]} == 0 )); then
     ((SKIP_EMPTY++))


### PR DESCRIPTION
## Summary
- ajoute le chemin absolu du répertoire inspecté dans les journaux de recherche des médias
- facilite la vérification des chemins lorsque le service semble bloqué

## Testing
- shellcheck bin/offline_transcode.sh *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68e6b3bf1c7083318a4f3d781473ec72