### PR TITLE
Add scan phase with OCR and AI pipeline

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,14 @@ SYSDDIR := /etc/systemd/system
 UDEVDIR := /etc/udev/rules.d
 CONFIG := /etc/dvdarchiver.conf
 
-BIN_SCRIPTS := bin/do_rip.sh bin/queue_enqueue.sh bin/queue_consumer.sh
+BIN_SCRIPTS := bin/do_rip.sh bin/queue_enqueue.sh bin/queue_consumer.sh bin/scan_enqueue.sh bin/scan_consumer.sh
 LIB_SCRIPTS := bin/lib/common.sh bin/lib/hash.sh bin/lib/techdump.sh
-SYSTEMD_UNITS := systemd/dvdarchiver-queue-consumer.service systemd/dvdarchiver-queue-consumer.path systemd/dvdarchiver-queue-consumer.timer
+SYSTEMD_UNITS := systemd/dvdarchiver-queue-consumer.service systemd/dvdarchiver-queue-consumer.path systemd/dvdarchiver-queue-consumer.timer \
+                  systemd/dvdarchiver-scan-consumer.service systemd/dvdarchiver-scan-consumer.path
 UDEV_RULE := udev/99-dvdarchiver.rules
+PY_SOURCES := $(wildcard bin/scan/*.py)
 
-.PHONY: install uninstall lint test-shellcheck
+.PHONY: install uninstall lint fmt test test-shellcheck
 
 install:
 ./install.sh --with-systemd --with-udev --prefix=$(PREFIX)
@@ -21,7 +23,23 @@ uninstall:
 	rm -f $(addprefix $(SYSDDIR)/,$(notdir $(SYSTEMD_UNITS)))
 	rm -f $(UDEVDIR)/$(notdir $(UDEV_RULE))
 
-lint: test-shellcheck
+lint:
+	@if command -v ruff >/dev/null 2>&1; then \
+		ruff check $(PY_SOURCES); \
+	else \
+		echo "ruff non disponible"; \
+	fi
+	$(MAKE) test-shellcheck
+
+fmt:
+	@if command -v black >/dev/null 2>&1; then \
+		black $(PY_SOURCES); \
+	else \
+		echo "black non disponible"; \
+	fi
+
+test:
+	python3 -m compileall bin/scan
 
 test-shellcheck:
 	@if command -v shellcheck >/dev/null 2>&1; then \

--- a/bin/scan/ai_analyzer.py
+++ b/bin/scan/ai_analyzer.py
@@ -1,0 +1,100 @@
+"""Gestion du prompt et interprétation de la réponse IA."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, List
+
+import ai_providers
+
+PROMPT_TEMPLATE = (
+    "Tu es un assistant qui interprète la structure d’un DVD-Video.\n"
+    "Données OCR (menus) = {ocr}.\n"
+    "Structure technique (lsdvd/mkv) = {struct}.\n"
+    "Métadonnées disque = {fingerprint}.\n"
+    "Objectifs :\n\n"
+    "1. Déduire le titre probable du film/série (si possible) et la langue principale.\n"
+    "2. Classer le contenu : \"film\" | \"serie\" | \"autre\".\n"
+    "3. Associer les libellés de menu aux titres détectés (main feature / bonus / trailer / épisodes).\n"
+    "4. Retourner un JSON strict unique :\n\n"
+    "{json_schema}\n\n"
+    "Ne renvoie rien d’autre que ce JSON (pas de texte hors JSON)."
+)
+
+JSON_SCHEMA = (
+    "{\"movie_title\":\"string|null\",\"content_type\":\"film|serie|autre\",\"language\":\"fr|en|...|unknown\","
+    "\"menu_labels\":[\"Play\",\"Chapters\",\"Subtitles\",\"Bonus\"],\"mapping\":{\"title_1\":\"Main Feature\","
+    "\"title_2\":\"Bonus: Making Of\"},\"confidence\":0.0}"
+)
+
+
+def _heuristic_summary(struct: Dict[str, object], normalized_labels: Dict[str, object]) -> Dict[str, object]:
+    titles = struct.get("titles", []) or []
+    movie_title = None
+    language = normalized_labels.get("language", "unknown")
+    if titles:
+        first = titles[0]
+        movie_title = first.get("filename") or f"Titre {first.get('index')}"
+    menu_labels = [entry.get("text") for entry in normalized_labels.get("raw", [])]
+    return {
+        "movie_title": movie_title,
+        "content_type": "autre" if len(titles) != 1 else "film",
+        "language": language or "unknown",
+        "menu_labels": menu_labels,
+        "mapping": {},
+        "confidence": 0.3,
+    }
+
+
+def infer_structure(
+    ocr_texts: List[Dict[str, object]],
+    normalized_labels: Dict[str, object],
+    struct: Dict[str, object],
+    fingerprint: Dict[str, object],
+    disc_dir,
+    config: Dict[str, object],
+) -> Dict[str, object]:
+    """Applique le prompt IA et renvoie la structure interprétée."""
+
+    llm_enable = bool(config.get("llm_enable", True))
+    cfg = ai_providers.LLMConfig.from_env()
+
+    payload = {
+        "inference": None,
+        "source": "heuristics",
+        "used": False,
+        "provider": cfg.provider,
+        "model": cfg.model,
+        "disc_dir": str(disc_dir),
+    }
+
+    if not llm_enable:
+        logging.info("LLM désactivé, retour heuristique")
+        payload["inference"] = _heuristic_summary(struct, normalized_labels)
+        return payload
+
+    client = ai_providers.build_client(cfg)
+
+    prompt = PROMPT_TEMPLATE.format(
+        ocr=json.dumps(ocr_texts, ensure_ascii=False),
+        struct=json.dumps(struct, ensure_ascii=False),
+        fingerprint=json.dumps(fingerprint, ensure_ascii=False),
+        json_schema=JSON_SCHEMA,
+    )
+
+    response = ""
+    try:
+        response = client.complete(prompt)
+        logging.debug("Réponse brute IA: %s", response)
+        data = json.loads(response)
+        payload.update({"inference": data, "source": "ia", "used": True, "raw_response": response})
+    except json.JSONDecodeError as exc:
+        logging.error("Réponse IA non JSON: %s", exc)
+        payload.update({"error": f"invalid_json: {exc}", "raw_response": response})
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Erreur appel IA: %s", exc)
+        payload.update({"error": str(exc)})
+    finally:
+        if not payload.get("inference"):
+            payload.setdefault("fallback", _heuristic_summary(struct, normalized_labels))
+    return payload

--- a/bin/scan/ai_providers.py
+++ b/bin/scan/ai_providers.py
@@ -1,0 +1,116 @@
+"""Abstraction des différents fournisseurs LLM."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import requests
+except ImportError:  # pragma: no cover
+    requests = None  # type: ignore
+
+
+@dataclass
+class LLMConfig:
+    provider: str
+    model: str
+    endpoint: str
+    api_key: str
+    timeout: int
+    temperature: float
+
+    @classmethod
+    def from_env(cls) -> "LLMConfig":
+        return cls(
+            provider=os.environ.get("LLM_PROVIDER", "mock"),
+            model=os.environ.get("LLM_MODEL", "mock"),
+            endpoint=os.environ.get("LLM_ENDPOINT", ""),
+            api_key=os.environ.get("LLM_API_KEY", ""),
+            timeout=int(os.environ.get("LLM_TIMEOUT_SEC", "60")),
+            temperature=float(os.environ.get("LLM_TEMPERATURE", "0.2")),
+        )
+
+
+class LLMClient:
+    def complete(self, prompt: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class OpenAIClient(LLMClient):
+    def __init__(self, cfg: LLMConfig) -> None:
+        self.cfg = cfg
+        self.endpoint = cfg.endpoint.rstrip("/") or "https://api.openai.com/v1"
+
+    def complete(self, prompt: str) -> str:
+        if not requests:
+            raise RuntimeError("Le module requests est requis pour OpenAIClient")
+        url = f"{self.endpoint}/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if self.cfg.api_key:
+            headers["Authorization"] = f"Bearer {self.cfg.api_key}"
+        payload = {
+            "model": self.cfg.model,
+            "temperature": self.cfg.temperature,
+            "messages": [
+                {"role": "system", "content": "Tu es un assistant d'analyse DVD."},
+                {"role": "user", "content": prompt},
+            ],
+        }
+        logging.debug("Appel OpenAI %s", url)
+        response = requests.post(url, headers=headers, json=payload, timeout=self.cfg.timeout)
+        response.raise_for_status()
+        data = response.json()
+        choice = data["choices"][0]["message"]["content"]
+        return str(choice)
+
+
+class OllamaClient(LLMClient):
+    def __init__(self, cfg: LLMConfig) -> None:
+        self.cfg = cfg
+        self.endpoint = cfg.endpoint.rstrip("/") or "http://localhost:11434"
+
+    def complete(self, prompt: str) -> str:
+        if not requests:
+            raise RuntimeError("Le module requests est requis pour OllamaClient")
+        url = f"{self.endpoint}/api/generate"
+        payload = {
+            "model": self.cfg.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": self.cfg.temperature},
+        }
+        logging.debug("Appel Ollama %s", url)
+        response = requests.post(url, json=payload, timeout=self.cfg.timeout)
+        response.raise_for_status()
+        data = response.json()
+        return str(data.get("response", ""))
+
+
+class MockClient(LLMClient):
+    def __init__(self, cfg: Optional[LLMConfig] = None) -> None:
+        self.cfg = cfg or LLMConfig("mock", "mock", "", "", 1, 0.0)
+
+    def complete(self, prompt: str) -> str:  # pragma: no cover - trivial
+        logging.info("Mock LLM utilisé")
+        return json.dumps(
+            {
+                "movie_title": None,
+                "content_type": "autre",
+                "language": "unknown",
+                "menu_labels": [],
+                "mapping": {},
+                "confidence": 0.1,
+            }
+        )
+
+
+def build_client(cfg: LLMConfig) -> LLMClient:
+    provider = cfg.provider.lower()
+    if provider == "openai":
+        return OpenAIClient(cfg)
+    if provider == "ollama":
+        return OllamaClient(cfg)
+    return MockClient(cfg)

--- a/bin/scan/heuristics.py
+++ b/bin/scan/heuristics.py
@@ -1,0 +1,81 @@
+"""Heuristiques d'association des menus avec la structure technique."""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List, Optional
+
+
+def detect_main_feature(struct: Dict[str, object]) -> Optional[Dict[str, object]]:
+    """Retourne le titre principal estimé à partir des durées."""
+
+    titles: List[Dict[str, object]] = list(struct.get("titles", []))  # type: ignore[arg-type]
+    if not titles:
+        return None
+
+    candidates = [t for t in titles if t.get("runtime_s")]
+    if not candidates:
+        return None
+
+    main = max(candidates, key=lambda t: t.get("runtime_s", 0))
+    max_runtime = main.get("runtime_s", 0)
+    similar = [t for t in candidates if abs(t.get("runtime_s", 0) - max_runtime) <= 180]
+    if len(similar) > 1:
+        main = {**main, "series_candidates": [t.get("index") for t in similar]}
+    logging.debug("Main feature détectée: %s", main)
+    return main
+
+
+def map_menu_labels_to_titles(
+    normalized_labels: Dict[str, object],
+    struct: Dict[str, object],
+    runtime_tol: int,
+    min_conf: float,
+) -> Dict[str, str]:
+    """Associe les étiquettes de menus aux titres connus."""
+
+    mapping: Dict[str, str] = {}
+    titles: List[Dict[str, object]] = list(struct.get("titles", []))  # type: ignore[arg-type]
+    if not titles:
+        return mapping
+
+    main = detect_main_feature(struct)
+    if main:
+        mapping[f"title_{main.get('index')}"] = "Main Feature"
+
+    categories: Dict[str, List[Dict[str, object]]] = normalized_labels.get("categories", {})  # type: ignore[assignment]
+
+    # Bonus = titres courts (< 25 min) si libellé bonus présent
+    bonus_labels = categories.get("bonus", []) if isinstance(categories, dict) else []
+    if bonus_labels:
+        for title in titles:
+            runtime = title.get("runtime_s") or 0
+            if runtime and runtime <= 1500 and any(
+                (label.get("confidence") or 1.0) >= min_conf for label in bonus_labels
+            ):
+                mapping[f"title_{title.get('index')}"] = "Bonus"
+
+    # Épisodes: associer par index si libellés contiennent des numéros
+    episode_labels = categories.get("episodes", []) if isinstance(categories, dict) else []
+    if episode_labels:
+        for label in episode_labels:
+            text = str(label.get("text", ""))
+            for title in titles:
+                idx = title.get("index")
+                if idx and str(idx) in text:
+                    mapping[f"title_{idx}"] = f"Episode {idx}"
+
+    # Chapitres: si chapitres courts
+    chapter_labels = categories.get("chapters", []) if isinstance(categories, dict) else []
+    if chapter_labels and main:
+        mapping.setdefault(f"title_{main.get('index')}", "Main Feature (Chapitres)")
+
+    if main and len(titles) > 1:
+        longest = main.get("runtime_s") or 0
+        for title in titles:
+            runtime = title.get("runtime_s") or 0
+            if title.get("index") == main.get("index"):
+                continue
+            if abs(longest - runtime) <= runtime_tol:
+                mapping.setdefault(f"title_{title.get('index')}", "Episode")
+
+    return mapping

--- a/bin/scan/ocr.py
+++ b/bin/scan/ocr.py
@@ -1,0 +1,101 @@
+"""Fonctions utilitaires pour l'OCR des menus DVD."""
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Dict, List, Sequence
+
+try:
+    import pytesseract  # type: ignore
+    from PIL import Image  # type: ignore
+except ImportError:  # pragma: no cover - dépendances optionnelles
+    pytesseract = None  # type: ignore
+    Image = None  # type: ignore
+
+
+LANG_KEYWORDS = {
+    "fr": ["lecture", "chapit", "bonus", "version", "langue", "sous-titres"],
+    "en": ["play", "chapter", "bonus", "setup", "audio", "subtitle"],
+    "es": ["reproduc", "capít", "idioma", "subtít"],
+    "de": ["wieder", "kapitel", "bonus", "sprache", "untertitel"],
+    "it": ["riprod", "capitol", "bonus", "lingua", "sottotit"],
+}
+
+CANONICAL_LABELS = {
+    "play": ["play", "lecture", "jouer", "leer", "start", "film"],
+    "chapters": ["chap", "scene", "kapitel"],
+    "bonus": ["bonus", "extras", "suppl", "extra"],
+    "audio": ["audio", "lang", "voix", "idioma", "sprache"],
+    "subtitles": ["subtitle", "sous", "subt", "untertitel"],
+    "episodes": ["episode", "épisode", "capitulo", "episodio"],
+}
+
+
+def _ocr_with_pytesseract(image_path: Path, langs: str) -> Dict[str, object]:
+    assert pytesseract and Image  # garde pour le type-checker
+    image = Image.open(image_path)
+    data = pytesseract.image_to_data(image, lang=langs, output_type=pytesseract.Output.DICT)
+    text = " ".join(t for t in data.get("text", []) if t.strip())
+    confidences = [int(c) for c in data.get("conf", []) if c not in {"-1", ""}]
+    confidence = (sum(confidences) / (len(confidences) * 100)) if confidences else None
+    return {"text": text.strip(), "frame": str(image_path), "confidence": confidence}
+
+
+def _ocr_with_cli(image_path: Path, langs: str, bin_path: str) -> Dict[str, object]:
+    cmd = [bin_path, str(image_path), "stdout", "-l", langs]
+    logging.debug("Appel tesseract CLI: %s", " ".join(cmd))
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        text = result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        logging.warning("OCR CLI échoué pour %s: %s", image_path, exc)
+        text = ""
+    return {"text": text, "frame": str(image_path), "confidence": None}
+
+
+def ocr_frames(paths: Sequence[str | Path], langs: str, bin_path: str = "tesseract") -> List[Dict[str, object]]:
+    """Retourne une liste de dictionnaires OCR."""
+
+    results: List[Dict[str, object]] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if pytesseract and Image:
+            try:
+                results.append(_ocr_with_pytesseract(path, langs))
+                continue
+            except Exception as exc:  # pylint: disable=broad-except
+                logging.warning("OCR pytesseract échoué pour %s: %s", path, exc)
+        results.append(_ocr_with_cli(path, langs, bin_path))
+    return results
+
+
+def detect_language(labels: Sequence[Dict[str, object]]) -> str:
+    counter = Counter()
+    for entry in labels:
+        text = entry.get("text", "")
+        lower = text.lower()
+        for lang, keywords in LANG_KEYWORDS.items():
+            if any(keyword in lower for keyword in keywords):
+                counter[lang] += 1
+    if not counter:
+        return "unknown"
+    return counter.most_common(1)[0][0]
+
+
+def normalize_labels(labels: Sequence[Dict[str, object]]) -> Dict[str, object]:
+    categories: Dict[str, List[Dict[str, object]]] = {key: [] for key in CANONICAL_LABELS}
+    cleaned: List[Dict[str, object]] = []
+    for entry in labels:
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        normalized = {"text": text, "frame": entry.get("frame"), "confidence": entry.get("confidence")}
+        cleaned.append(normalized)
+        lower = text.lower()
+        for canonical, keywords in CANONICAL_LABELS.items():
+            if any(keyword in lower for keyword in keywords):
+                categories.setdefault(canonical, []).append(normalized)
+    language = detect_language(cleaned)
+    return {"raw": cleaned, "categories": {k: v for k, v in categories.items() if v}, "language": language}

--- a/bin/scan/scanner.py
+++ b/bin/scan/scanner.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Orchestrateur de la phase 2 (scan + OCR + IA) du pipeline DVD."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import ai_analyzer  # type: ignore  # noqa: E402
+import heuristics  # type: ignore  # noqa: E402
+import ocr  # type: ignore  # noqa: E402
+import techparse  # type: ignore  # noqa: E402
+import writers  # type: ignore  # noqa: E402
+
+
+@dataclass
+class Config:
+    """Configuration lue depuis l'environnement."""
+
+    ffmpeg_bin: str = "ffmpeg"
+    ffprobe_bin: str = "ffprobe"
+    ocr_bin: str = "tesseract"
+    ocr_langs: str = "eng"
+    frame_rate_menu_fps: float = 1.0
+    frame_max_menu: int = 30
+    menu_vob_patterns: List[str] = field(default_factory=list)
+    struct_fallback_from_mkv: bool = True
+    runtime_tolerance_sec: int = 120
+    confidence_min: float = 0.5
+    llm_enable: bool = True
+    archive_layout_version: str = "1.0"
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        patterns = os.environ.get("MENU_VOB_GLOB", "VIDEO_TS.VOB VTS_*_0.VOB").split()
+        return cls(
+            ffmpeg_bin=os.environ.get("FFMPEG_BIN", "ffmpeg"),
+            ffprobe_bin=os.environ.get("FFPROBE_BIN", "ffprobe"),
+            ocr_bin=os.environ.get("OCR_BIN", "tesseract"),
+            ocr_langs=os.environ.get("OCR_LANGS", "eng+fra"),
+            frame_rate_menu_fps=float(os.environ.get("FRAME_RATE_MENU_FPS", "1")),
+            frame_max_menu=int(os.environ.get("FRAME_MAX_MENU", "30")),
+            menu_vob_patterns=patterns,
+            struct_fallback_from_mkv=os.environ.get("STRUCT_FALLBACK_FROM_MKV", "1") == "1",
+            runtime_tolerance_sec=int(os.environ.get("RUNTIME_TOLERANCE_SEC", "120")),
+            confidence_min=float(os.environ.get("CONFIDENCE_MIN", "0.5")),
+            llm_enable=os.environ.get("LLM_ENABLE", "1") == "1",
+            archive_layout_version=os.environ.get("ARCHIVE_LAYOUT_VERSION", "1.0"),
+        )
+
+
+class ScanError(Exception):
+    """Erreur bloquante lors du scan."""
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+def ensure_tool(name: str) -> bool:
+    return shutil.which(name) is not None
+
+
+def extract_menu_frames(
+    vob_paths: Iterable[Path],
+    output_dir: Path,
+    config: Config,
+) -> List[Path]:
+    """Extrait des frames de menus depuis des fichiers VOB avec ffmpeg."""
+
+    extracted: List[Path] = []
+    if not ensure_tool(config.ffmpeg_bin):
+        logging.warning("ffmpeg (%s) introuvable, extraction des menus ignorée", config.ffmpeg_bin)
+        return extracted
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    for vob in vob_paths:
+        if not vob.exists():
+            continue
+        stem = vob.stem.replace(" ", "_")
+        target_pattern = output_dir / f"{stem}_%03d.png"
+        for existing in output_dir.glob(f"{stem}_*.png"):
+            try:
+                existing.unlink()
+            except OSError:
+                logging.debug("Impossible de supprimer %s", existing)
+        cmd = [
+            config.ffmpeg_bin,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(vob),
+            "-vf",
+            f"fps={config.frame_rate_menu_fps}",
+            "-frames:v",
+            str(config.frame_max_menu),
+            str(target_pattern),
+        ]
+        logging.info("Extraction des menus via ffmpeg: %s", " ".join(cmd))
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as exc:
+            logging.warning("Extraction ffmpeg échouée pour %s: %s", vob, exc)
+            continue
+
+        for frame_path in sorted(output_dir.glob(f"{stem}_*.png")):
+            extracted.append(frame_path)
+
+    return extracted
+
+
+def list_menu_vobs(raw_dir: Path, config: Config) -> List[Path]:
+    matches: List[Path] = []
+    for pattern in config.menu_vob_patterns:
+        matches.extend(sorted(raw_dir.glob(pattern)))
+    return matches
+
+
+def load_fingerprint(disc_dir: Path) -> Dict[str, object]:
+    fingerprint_path = disc_dir / "tech" / "fingerprint.json"
+    if fingerprint_path.exists():
+        try:
+            return json.loads(fingerprint_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logging.warning("Impossible de lire fingerprint.json: %s", exc)
+    return {}
+
+
+def gather_menu_frames(disc_dir: Path, config: Config) -> List[Path]:
+    raw_dir = disc_dir / "raw"
+    if not raw_dir.exists():
+        logging.info("Répertoire raw/ absent, OCR des menus ignoré")
+        return []
+
+    vobs = list_menu_vobs(raw_dir, config)
+    if not vobs:
+        logging.info("Aucun VOB de menu détecté dans %s", raw_dir)
+        return []
+
+    frames_dir = disc_dir / "meta" / "ocr_frames"
+    return extract_menu_frames(vobs, frames_dir, config)
+
+
+def main() -> int:
+    setup_logging()
+    config = Config.from_env()
+
+    disc_dir_env = os.environ.get("DISC_DIR")
+    if not disc_dir_env:
+        logging.error("DISC_DIR non défini dans l'environnement")
+        return 1
+
+    disc_dir = Path(disc_dir_env).resolve()
+    logging.info("Démarrage scan pour %s", disc_dir)
+
+    if not disc_dir.exists():
+        logging.error("Le répertoire disque %s est introuvable", disc_dir)
+        return 1
+
+    metadata_path = disc_dir / "meta" / "metadata_ia.json"
+    if metadata_path.exists():
+        logging.info("metadata_ia.json déjà présent, rien à faire")
+        return 0
+
+    (disc_dir / "meta").mkdir(parents=True, exist_ok=True)
+
+    structure_path = disc_dir / "tech" / "structure.lsdvd.yml"
+    structure = {}
+    if structure_path.exists():
+        structure = techparse.parse_lsdvd(structure_path)
+
+    if not structure and config.struct_fallback_from_mkv:
+        mkv_dir = disc_dir / "mkv"
+        if mkv_dir.exists():
+            logging.info("Structure vide, fallback mkvmerge")
+            structure = techparse.probe_mkv_titles(mkv_dir)
+
+    fingerprint = load_fingerprint(disc_dir)
+
+    frame_paths = gather_menu_frames(disc_dir, config)
+    ocr_results: List[Dict[str, object]] = []
+    normalized_labels: Dict[str, object] = {}
+
+    if frame_paths:
+        logging.info("OCR sur %d frames", len(frame_paths))
+        try:
+            ocr_results = ocr.ocr_frames(frame_paths, config.ocr_langs, bin_path=config.ocr_bin)
+            normalized_labels = ocr.normalize_labels(ocr_results)
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error("Erreur OCR: %s", exc)
+            ocr_results = []
+            normalized_labels = {"raw": [], "categories": {}, "language": "unknown"}
+    else:
+        logging.info("Aucune frame extraite, OCR ignoré")
+        normalized_labels = {"raw": [], "categories": {}, "language": "unknown"}
+
+    main_feature = heuristics.detect_main_feature(structure)
+    mapping = heuristics.map_menu_labels_to_titles(
+        normalized_labels,
+        structure,
+        runtime_tol=config.runtime_tolerance_sec,
+        min_conf=config.confidence_min,
+    )
+
+    ia_payload = None
+    start = time.time()
+    try:
+        ia_payload = ai_analyzer.infer_structure(
+            ocr_texts=ocr_results,
+            normalized_labels=normalized_labels,
+            struct=structure,
+            fingerprint=fingerprint,
+            disc_dir=disc_dir,
+            config={
+                "llm_enable": config.llm_enable,
+                "runtime_tol": config.runtime_tolerance_sec,
+            },
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Erreur IA: %s", exc)
+        ia_payload = {"error": str(exc)}
+    finally:
+        duration = time.time() - start
+        logging.info("Analyse IA terminée en %.2fs", duration)
+
+    disc_uid = disc_dir.name
+
+    try:
+        writers.write_metadata_json(
+            out_path=metadata_path,
+            disc_uid=disc_uid,
+            struct=structure,
+            labels=normalized_labels,
+            mapping=mapping,
+            main_feature=main_feature,
+            layout_ver=config.archive_layout_version,
+            ia_payload=ia_payload,
+            ocr_results=ocr_results,
+            fingerprint=fingerprint,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Écriture metadata échouée: %s", exc)
+        return 1
+
+    logging.info("metadata_ia.json généré pour %s", disc_uid)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bin/scan/techparse.py
+++ b/bin/scan/techparse.py
@@ -1,0 +1,97 @@
+"""Parsing des structures techniques (lsdvd, mkvmerge)."""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    import yaml  # type: ignore
+except ImportError:  # pragma: no cover
+    yaml = None  # type: ignore
+
+
+def parse_lsdvd(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        return {}
+    try:
+        data = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logging.warning("Lecture lsdvd échouée: %s", exc)
+        return {}
+
+    if yaml:
+        try:
+            loaded = yaml.safe_load(data)
+        except yaml.YAMLError as exc:  # type: ignore[attr-defined]
+            logging.warning("YAML invalide pour %s: %s", path, exc)
+            return {}
+        titles = []
+        for title in loaded.get("track", []):
+            runtime = title.get("length")
+            if isinstance(runtime, str):
+                try:
+                    runtime = float(runtime)
+                except ValueError:
+                    parts = runtime.split(":")
+                    if len(parts) == 3:
+                        h, m, s = parts
+                        runtime = int(h) * 3600 + int(m) * 60 + float(s)
+                    else:
+                        runtime = None
+            titles.append(
+                {
+                    "index": title.get("ix"),
+                    "runtime_s": runtime,
+                    "chapters": len(title.get("chapter", [])),
+                    "audio_langs": [a.get("langcode") for a in title.get("audio", []) if a],
+                    "sub_langs": [s.get("langcode") for s in title.get("subpicture", []) if s],
+                    "angles": len(title.get("angle", [])),
+                }
+            )
+        return {"source": "lsdvd", "titles": titles}
+    logging.warning("PyYAML absent, structure lsdvd ignorée")
+    return {}
+
+
+def probe_mkv_titles(mkv_dir: Path) -> Dict[str, object]:
+    titles: List[Dict[str, object]] = []
+    mkvmerge_bin = "mkvmerge"
+    for mkv in sorted(mkv_dir.glob("*.mkv")):
+        cmd = [mkvmerge_bin, "-J", str(mkv)]
+        logging.debug("Probe mkvmerge: %s", " ".join(cmd))
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        except subprocess.CalledProcessError as exc:
+            logging.warning("mkvmerge -J échoué pour %s: %s", mkv, exc)
+            continue
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            logging.warning("JSON mkvmerge invalide pour %s: %s", mkv, exc)
+            continue
+        duration = payload.get("container", {}).get("properties", {}).get("duration")
+        if isinstance(duration, str):
+            try:
+                duration = float(duration)
+            except ValueError:
+                duration = None
+        tracks = payload.get("tracks", [])
+        audio_langs = [t.get("properties", {}).get("language") for t in tracks if t.get("type") == "audio"]
+        sub_langs = [t.get("properties", {}).get("language") for t in tracks if t.get("type") == "subtitles"]
+        titles.append(
+            {
+                "index": len(titles) + 1,
+                "runtime_s": duration,
+                "chapters": payload.get("chapters", {}).get("count"),
+                "audio_langs": [lang for lang in audio_langs if lang],
+                "sub_langs": [lang for lang in sub_langs if lang],
+                "angles": None,
+                "filename": mkv.name,
+            }
+        )
+    if not titles:
+        return {}
+    return {"source": "mkvmerge", "titles": titles}

--- a/bin/scan/writers.py
+++ b/bin/scan/writers.py
@@ -1,0 +1,74 @@
+"""Écriture du fichier metadata_ia.json."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+def write_metadata_json(
+    out_path: Path,
+    disc_uid: str,
+    struct: Dict[str, object],
+    labels: Dict[str, object],
+    mapping: Dict[str, str],
+    main_feature: Optional[Dict[str, object]],
+    layout_ver: str,
+    ia_payload: Optional[Dict[str, object]] = None,
+    ocr_results: Optional[List[Dict[str, object]]] = None,
+    fingerprint: Optional[Dict[str, object]] = None,
+) -> None:
+    out_path = Path(out_path)
+    ocr_results = ocr_results or []
+    fingerprint = fingerprint or {}
+    inference = (ia_payload or {}).get("inference") if ia_payload else None
+    if not inference:
+        inference = (ia_payload or {}).get("fallback") if ia_payload else None
+    if not inference:
+        inference = {
+            "movie_title": None,
+            "content_type": "autre",
+            "language": "unknown",
+            "menu_labels": [],
+            "mapping": {},
+            "confidence": 0.0,
+        }
+
+    payload = {
+        "disc_uid": disc_uid,
+        "layout_version": layout_ver,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "structure": struct,
+        "menus": {
+            "labels": labels,
+            "frames_used": [entry.get("frame") for entry in ocr_results if entry.get("frame")],
+            "language_detected": labels.get("language", "unknown") if isinstance(labels, dict) else "unknown",
+        },
+        "mapping": mapping,
+        "main_feature": main_feature,
+        "inferred": {
+            "movie_title": inference.get("movie_title"),
+            "content_type": inference.get("content_type", "autre"),
+            "language": inference.get("language", "unknown"),
+            "confidence": inference.get("confidence", 0.0),
+            "source": "ia" if (ia_payload or {}).get("used") else "heuristics",
+        },
+        "sources": {
+            "tech_dump": struct.get("source"),
+            "ocr_dir": str(out_path.parent / "ocr_frames"),
+            "llm": {
+                "provider": (ia_payload or {}).get("provider"),
+                "model": (ia_payload or {}).get("model"),
+                "used": (ia_payload or {}).get("used", False),
+                "error": (ia_payload or {}).get("error"),
+            },
+        },
+        "fingerprint": fingerprint,
+    }
+
+    payload["inferred"]["menu_labels"] = inference.get("menu_labels", [])
+    payload["inferred"]["mapping"] = inference.get("mapping", {})
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")

--- a/bin/scan_consumer.sh
+++ b/bin/scan_consumer.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/dvdarchiver.conf"
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck disable=SC1091
+  source "$CONFIG_FILE"
+fi
+
+SCAN_QUEUE_DIR="${SCAN_QUEUE_DIR:-/var/spool/dvdarchiver-scan}"
+SCAN_LOG_DIR="${SCAN_LOG_DIR:-/var/log/dvdarchiver-scan}"
+SCANNER_BIN="${SCANNER_BIN:-/usr/local/bin/scan/scanner.py}"
+SLEEP_SEC="${SCAN_IDLE_SLEEP_SEC:-10}"
+SCAN_TRIGGER_GLOB="${SCAN_TRIGGER_GLOB:-}"
+SCAN_ENQUEUE_BIN="${SCAN_ENQUEUE_BIN:-/usr/local/bin/scan_enqueue.sh}"
+
+mkdir -p "$SCAN_QUEUE_DIR" "$SCAN_LOG_DIR"
+
+log() {
+  printf '[scan_consumer] %s\n' "$*"
+}
+
+enqueue_ready_discs() {
+  local glob="$SCAN_TRIGGER_GLOB"
+  [[ -z "$glob" ]] && return
+  while IFS= read -r mkv_path; do
+    [[ -z "$mkv_path" ]] && continue
+    if [[ ! -e "$mkv_path" ]]; then
+      continue
+    fi
+    local disc_dir
+    disc_dir="$(dirname "$(dirname "$mkv_path")")"
+    if [[ -f "$disc_dir/meta/metadata_ia.json" ]]; then
+      continue
+    fi
+    if [[ -x "$SCAN_ENQUEUE_BIN" ]]; then
+      "$SCAN_ENQUEUE_BIN" "$disc_dir" || log "Échec enqueue $disc_dir"
+    else
+      log "SCAN_ENQUEUE_BIN inexistant: $SCAN_ENQUEUE_BIN"
+    fi
+  done < <(compgen -G "$glob" 2>/dev/null || true)
+}
+
+process_job() {
+  local job_file="$1"
+  # shellcheck disable=SC1090
+  source "$job_file"
+  if [[ -z "${DISC_DIR:-}" ]]; then
+    log "DISC_DIR manquant dans $job_file"
+    return 1
+  fi
+  local disc_name
+  disc_name="$(basename "$DISC_DIR")"
+  local timestamp
+  timestamp="$(date +%Y%m%d-%H%M%S)"
+  local log_file="$SCAN_LOG_DIR/scan-${disc_name}-${timestamp}.log"
+  log "Traitement $job_file pour $DISC_DIR"
+  export DISC_DIR
+  if python3 "$SCANNER_BIN" >>"$log_file" 2>&1; then
+    log "Succès $DISC_DIR"
+    mv "$job_file" "${job_file%.job}.done"
+  else
+    log "Échec $DISC_DIR (voir $log_file)"
+    mv "$job_file" "${job_file%.job}.err"
+  fi
+}
+
+while true; do
+  enqueue_ready_discs
+  mapfile -t jobs < <(find "$SCAN_QUEUE_DIR" -maxdepth 1 -type f -name 'SCAN_*.job' | sort)
+  if [[ ${#jobs[@]} -eq 0 ]]; then
+    sleep "$SLEEP_SEC"
+    continue
+  fi
+  for job in "${jobs[@]}"; do
+    process_job "$job" || true
+  done
+done

--- a/bin/scan_enqueue.sh
+++ b/bin/scan_enqueue.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/dvdarchiver.conf"
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck disable=SC1091
+  source "$CONFIG_FILE"
+fi
+
+SCAN_QUEUE_DIR="${SCAN_QUEUE_DIR:-/var/spool/dvdarchiver-scan}"
+
+log() {
+  printf '[scan_enqueue] %s\n' "$*"
+}
+
+usage() {
+  echo "Usage: $0 <DISC_DIR>" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+disc_dir="$1"
+if [[ ! -d "$disc_dir" ]]; then
+  echo "Répertoire disque introuvable: $disc_dir" >&2
+  exit 1
+fi
+
+disc_dir="$(cd "$disc_dir" && pwd)"
+meta_json="$disc_dir/meta/metadata_ia.json"
+if [[ -f "$meta_json" ]]; then
+  log "Déjà traité ($meta_json)"
+  exit 0
+fi
+
+mkdir -p "$SCAN_QUEUE_DIR"
+
+existing_job=""
+shopt -s nullglob
+for job in "$SCAN_QUEUE_DIR"/SCAN_*.job; do
+  if grep -q "^DISC_DIR=\"$disc_dir\"" "$job"; then
+    existing_job="$job"
+    break
+  fi
+done
+shopt -u nullglob
+
+if [[ -n "$existing_job" ]]; then
+  log "Job déjà en file: $existing_job"
+  exit 0
+fi
+
+ts="$(date +%s)"
+rand="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 6 || echo RAND)"
+job_file="$SCAN_QUEUE_DIR/SCAN_${ts}_${rand}.job"
+
+tmp_job="${job_file}.tmp"
+cat <<EOF >"$tmp_job"
+DISC_DIR="$disc_dir"
+ACTION="SCAN"
+EOF
+mv "$tmp_job" "$job_file"
+log "Job créé: $job_file"

--- a/docs/SCAN_PIPELINE.md
+++ b/docs/SCAN_PIPELINE.md
@@ -1,0 +1,77 @@
+# Phase 2 – Pipeline Scan & IA
+
+La phase 2 complète le rip en analysant les archives DVD existantes pour produire `meta/metadata_ia.json`.
+
+## Prérequis
+
+Installer les dépendances suivantes (best-effort) :
+
+```bash
+apt install tesseract-ocr ffmpeg mkvtoolnix lsdvd python3-venv
+```
+
+## Configuration
+
+Le fichier `/etc/dvdarchiver.conf` doit inclure la section « Phase 2 » :
+
+```bash
+# --- Phase 2: Scan & OCR ---
+SCAN_QUEUE_DIR="/var/spool/dvdarchiver-scan"
+SCAN_LOG_DIR="/var/log/dvdarchiver-scan"
+SCAN_TRIGGER_GLOB="${DEST:-/mnt/media_master}/*/mkv/title*.mkv"
+# ... voir etc/dvdarchiver.conf.sample pour la liste complète
+```
+
+Chaque script source ce fichier et les variables peuvent être surchargées via l’environnement.
+
+## File d’attente
+
+* `scan_enqueue.sh <DISC_DIR>` ajoute un job `SCAN_*.job` dans `${SCAN_QUEUE_DIR}`
+  * Idempotent (un seul job par disque).
+  * Ignore les disques déjà scannés (`meta/metadata_ia.json`).
+* `scan_consumer.sh` tourne en boucle :
+  * détecte les dossiers prêts via `SCAN_TRIGGER_GLOB` et appelle `scan_enqueue.sh`.
+  * consomme la file, lance `scanner.py` et journalise dans `${SCAN_LOG_DIR}`.
+
+## Orchestrateur Python
+
+`bin/scan/scanner.py` pilote les étapes :
+
+1. Lecture de la structure (`tech/structure.lsdvd.yml` ou fallback `mkvmerge -J`).
+2. Extraction d’images de menus (`ffmpeg` sur `raw/*.VOB`).
+3. OCR (`pytesseract` ou CLI Tesseract) puis normalisation des libellés.
+4. Heuristiques : détection du main feature, bonus, épisodes.
+5. Appel IA via `ai_providers` (OpenAI, Ollama ou mock). Si `LLM_ENABLE=0`, heuristique seule.
+6. Écriture de `meta/metadata_ia.json` via `writers.py` (idempotent).
+
+Les logs détaillent les étapes et durées. En cas d’échec OCR/IA, un JSON minimal reste généré.
+
+## Sortie `metadata_ia.json`
+
+```json
+{
+  "disc_uid": "dvd_xxxxx",
+  "layout_version": "1.0",
+  "structure": {...},
+  "menus": {...},
+  "inferred": {
+    "movie_title": "...",
+    "content_type": "film|serie|autre",
+    "language": "fr|en|...|unknown",
+    "confidence": 0.0-1.0,
+    "source": "ia|heuristics",
+    "menu_labels": [...],
+    "mapping": {...}
+  }
+}
+```
+
+## Dépannage
+
+* **Pas de VOB dans `raw/`** : l’OCR est ignoré, la structure provient des fichiers MKV si le fallback est activé.
+* **LLM désactivé (`LLM_ENABLE=0`)** : la sortie provient des heuristiques locales.
+* **Absence de PyYAML/pytesseract** : le module bascule sur des parseurs / OCR CLI best-effort.
+
+## Lancement systemd
+
+Voir `systemd/README-systemd-scan.md` pour l’activation du `path` et du service consumer.

--- a/etc/dvdarchiver.conf.sample
+++ b/etc/dvdarchiver.conf.sample
@@ -30,3 +30,33 @@ ALLOW_ISO_DUMP=0                    # si 1, dumper ISO brute dans raw/
 
 # --- Archivage: structure ---
 ARCHIVE_LAYOUT_VERSION="1.0"
+
+# --- Phase 2: Scan & OCR ---
+SCAN_QUEUE_DIR="/var/spool/dvdarchiver-scan"
+SCAN_LOG_DIR="/var/log/dvdarchiver-scan"
+
+# Détection de dossiers prêts (phase 1 terminée)
+SCAN_TRIGGER_GLOB="${DEST:-/mnt/media_master}/*/mkv/title*.mkv"
+
+# OCR / vidéo
+FFMPEG_BIN="ffmpeg"
+FFPROBE_BIN="ffprobe"
+OCR_BIN="tesseract"
+OCR_LANGS="eng+fra+spa+ita+deu"
+FRAME_RATE_MENU_FPS=1
+FRAME_MAX_MENU=30
+MENU_VOB_GLOB="VIDEO_TS.VOB VTS_*_0.VOB"
+STRUCT_FALLBACK_FROM_MKV=1
+
+# Heuristiques & seuils
+RUNTIME_TOLERANCE_SEC=120
+CONFIDENCE_MIN=0.50
+
+# --- IA / LLM ---
+LLM_ENABLE=1
+LLM_PROVIDER="openai"
+LLM_MODEL="gpt-4o-mini"
+LLM_ENDPOINT=""
+LLM_API_KEY=""
+LLM_TIMEOUT_SEC=60
+LLM_TEMPERATURE=0.2

--- a/systemd/README-systemd-scan.md
+++ b/systemd/README-systemd-scan.md
@@ -1,0 +1,22 @@
+# Unités systemd – Phase 2 (Scan IA)
+
+## Installation
+
+```bash
+cp systemd/dvdarchiver-scan-consumer.service /etc/systemd/system/
+cp systemd/dvdarchiver-scan-consumer.path /etc/systemd/system/
+systemctl daemon-reload
+systemctl enable --now dvdarchiver-scan-consumer.service
+systemctl enable --now dvdarchiver-scan-consumer.path
+```
+
+## Journaux
+
+* `journalctl -u dvdarchiver-scan-consumer.service`
+* Fichiers détaillés : `${SCAN_LOG_DIR}/scan-<disc>-<timestamp>.log`
+
+## Test manuel
+
+```bash
+scan_enqueue.sh "${DEST}/<DISC_UID>"
+```

--- a/systemd/dvdarchiver-scan-consumer.path
+++ b/systemd/dvdarchiver-scan-consumer.path
@@ -1,0 +1,11 @@
+# /etc/systemd/system/dvdarchiver-scan-consumer.path
+[Unit]
+Description=Détection des archives prêtes pour scan IA
+
+[Path]
+EnvironmentFile=/etc/dvdarchiver.conf
+PathExistsGlob=%E{SCAN_TRIGGER_GLOB}
+Unit=dvdarchiver-scan-consumer.service
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/dvdarchiver-scan-consumer.service
+++ b/systemd/dvdarchiver-scan-consumer.service
@@ -1,0 +1,16 @@
+# /etc/systemd/system/dvdarchiver-scan-consumer.service
+[Unit]
+Description=DVD Archiver - Consumer file de scan IA
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/dvdarchiver.conf
+ExecStart=/usr/local/bin/scan_consumer.sh
+Restart=on-failure
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add the Phase 2 Python orchestrator for OCR, heuristics, AI analysis, and metadata writing
- provide scan queue scripts, systemd units, and installer/config updates for automated processing
- document the new scan pipeline and extend build helpers for formatting and linting

## Testing
- python3 -m compileall bin/scan

------
https://chatgpt.com/codex/tasks/task_b_68ebe63cd22c8331b98d2abe20b1a4fb