### PR TITLE
Add Phase 2 scan module with Ollama default

### DIFF
--- a/dvd-archiver/Makefile
+++ b/dvd-archiver/Makefile
@@ -1,0 +1,40 @@
+PREFIX ?= /usr/local
+BINDIR := $(PREFIX)/bin
+SCANDIR := $(BINDIR)/scan
+SYSTEMD_DIR := /etc/systemd/system
+CONFIG := /etc/dvdarchiver.conf
+REMOVE_CONF ?= 0
+PY_SOURCES := $(wildcard bin/scan/*.py)
+
+.PHONY: install uninstall fmt lint
+
+install:
+	./install.sh
+
+uninstall:
+	rm -f $(BINDIR)/scan_enqueue.sh $(BINDIR)/scan_consumer.sh
+	rm -f $(addprefix $(SCANDIR)/,$(notdir $(PY_SOURCES)))
+	rmdir --ignore-fail-on-non-empty $(SCANDIR) || true
+	rm -f $(SYSTEMD_DIR)/dvdarchiver-scan-consumer.service $(SYSTEMD_DIR)/dvdarchiver-scan-consumer.path
+	@if command -v systemctl >/dev/null 2>&1; then \
+		systemctl disable --now dvdarchiver-scan-consumer.path >/dev/null 2>&1 || true; \
+		systemctl daemon-reload; \
+	fi
+ifeq ($(REMOVE_CONF),1)
+	@echo "Suppression de $(CONFIG)"
+	rm -f $(CONFIG)
+endif
+
+fmt:
+	@if command -v black >/dev/null 2>&1; then \
+		black $(PY_SOURCES); \
+	else \
+		echo "black indisponible"; \
+	fi
+
+lint:
+	@if command -v ruff >/dev/null 2>&1; then \
+		ruff check $(PY_SOURCES); \
+	else \
+		echo "ruff indisponible"; \
+	fi

--- a/dvd-archiver/bin/scan/ai_analyzer.py
+++ b/dvd-archiver/bin/scan/ai_analyzer.py
@@ -1,0 +1,79 @@
+"""Analyse IA des structures DVD."""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Dict, List
+
+import ai_providers
+
+
+def _build_prompt(
+    ocr_texts: List[Dict[str, object]],
+    normalized_labels: Dict[str, object],
+    struct: Dict[str, object],
+    fingerprint: Dict[str, object],
+) -> str:
+    schema = """
+Tu dois répondre avec un JSON strict respectant exactement ce schéma :
+{
+  "movie_title": "string|null",
+  "content_type": "film|serie|autre",
+  "language": "fr|en|es|de|it|...|unknown",
+  "menu_labels": ["Play","Chapters","Subtitles","Bonus"],
+  "mapping": {"title_1":"Main Feature","title_2":"Bonus: Making Of"},
+  "confidence": 0.0
+}
+""".strip()
+
+    prompt = (
+        "Tu es un assistant expert en DVD. Analyse les données OCR, la structure technique et les empreintes pour déduire la nature du contenu.\n"
+        "Consignes :\n"
+        "- Travaille en français.\n"
+        "- Si l'information manque, reste prudent et baisse la confiance.\n"
+        "- Ne devine pas de titre inventé.\n"
+        f"{schema}\n"
+        "Données OCR (liste de textes avec confiance) :\n"
+        f"{json.dumps(ocr_texts, ensure_ascii=False)}\n"
+        "Labels normalisés :\n"
+        f"{json.dumps(normalized_labels, ensure_ascii=False)}\n"
+        "Structure technique (durées, langues) :\n"
+        f"{json.dumps(struct, ensure_ascii=False)}\n"
+        "Empreinte disque :\n"
+        f"{json.dumps(fingerprint, ensure_ascii=False)}\n"
+        "Réponds uniquement avec le JSON demandé."
+    )
+    return prompt
+
+
+def infer_structure(
+    ocr_texts: List[Dict[str, object]],
+    normalized_labels: Dict[str, object],
+    struct: Dict[str, object],
+    fingerprint: Dict[str, object],
+) -> Dict[str, object] | None:
+    """Appelle le LLM configuré pour analyser la structure."""
+
+    cfg = ai_providers.LLMConfig.from_env()
+    client = ai_providers.build_client(cfg)
+    prompt = _build_prompt(ocr_texts, normalized_labels, struct, fingerprint)
+    logging.info(
+        "Appel IA via %s (modèle=%s, endpoint=%s)", cfg.provider, cfg.model, cfg.endpoint
+    )
+    raw_response = client.complete(prompt)
+    logging.debug("Réponse brute IA: %s", raw_response)
+
+    try:
+        payload = json.loads(raw_response)
+    except json.JSONDecodeError as exc:
+        logging.error("Réponse IA invalide: %s", exc)
+        return None
+
+    if not isinstance(payload, dict):
+        logging.error("Réponse IA inattendue (type %s)", type(payload))
+        return None
+
+    payload.setdefault("source", cfg.provider)
+    payload.setdefault("model", cfg.model)
+    return payload
+

--- a/dvd-archiver/bin/scan/ai_providers.py
+++ b/dvd-archiver/bin/scan/ai_providers.py
@@ -1,0 +1,128 @@
+"""Clients LLM pour l'analyse IA."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass
+from typing import Optional
+
+try:
+    import requests
+except ImportError:  # pragma: no cover - requests optionnel
+    requests = None  # type: ignore
+
+
+DEFAULT_PROVIDER = "ollama"
+DEFAULT_ENDPOINT = "http://127.0.0.1:11434"
+DEFAULT_MODEL = "qwen2.5:14b-instruct-q4_K_M"
+DEFAULT_TIMEOUT = 3600
+DEFAULT_TEMPERATURE = 0.2
+
+
+@dataclass
+class LLMConfig:
+    provider: str
+    model: str
+    endpoint: str
+    api_key: str
+    timeout: int
+    temperature: float
+
+    @classmethod
+    def from_env(cls) -> "LLMConfig":
+        return cls(
+            provider=os.environ.get("LLM_PROVIDER", DEFAULT_PROVIDER),
+            model=os.environ.get("LLM_MODEL", DEFAULT_MODEL),
+            endpoint=os.environ.get("LLM_ENDPOINT", DEFAULT_ENDPOINT),
+            api_key=os.environ.get("LLM_API_KEY", ""),
+            timeout=int(os.environ.get("LLM_TIMEOUT_SEC", str(DEFAULT_TIMEOUT))),
+            temperature=float(os.environ.get("LLM_TEMPERATURE", str(DEFAULT_TEMPERATURE))),
+        )
+
+
+class LLMClient:
+    """Interface simple de complétion."""
+
+    def complete(self, prompt: str) -> str:  # pragma: no cover - interface
+        raise NotImplementedError
+
+
+class OllamaClient(LLMClient):
+    def __init__(self, cfg: LLMConfig) -> None:
+        self.cfg = cfg
+        self.endpoint = cfg.endpoint.rstrip("/") or DEFAULT_ENDPOINT
+
+    def complete(self, prompt: str) -> str:
+        if not requests:
+            raise RuntimeError("Le module requests est requis pour OllamaClient")
+        url = f"{self.endpoint}/api/generate"
+        payload = {
+            "model": self.cfg.model,
+            "prompt": prompt,
+            "stream": False,
+            "options": {"temperature": self.cfg.temperature},
+        }
+        logging.debug("Appel Ollama %s", url)
+        response = requests.post(url, json=payload, timeout=self.cfg.timeout)
+        response.raise_for_status()
+        data = response.json()
+        return str(data.get("response", ""))
+
+
+class OpenAIClient(LLMClient):
+    def __init__(self, cfg: LLMConfig) -> None:
+        self.cfg = cfg
+        self.endpoint = cfg.endpoint.rstrip("/") or "https://api.openai.com/v1"
+
+    def complete(self, prompt: str) -> str:
+        if not requests:
+            raise RuntimeError("Le module requests est requis pour OpenAIClient")
+        url = f"{self.endpoint}/chat/completions"
+        headers = {"Content-Type": "application/json"}
+        if self.cfg.api_key:
+            headers["Authorization"] = f"Bearer {self.cfg.api_key}"
+        payload = {
+            "model": self.cfg.model,
+            "temperature": self.cfg.temperature,
+            "messages": [
+                {"role": "system", "content": "Tu es un assistant d'analyse de menus DVD."},
+                {"role": "user", "content": prompt},
+            ],
+        }
+        logging.debug("Appel OpenAI %s", url)
+        response = requests.post(url, headers=headers, json=payload, timeout=self.cfg.timeout)
+        response.raise_for_status()
+        data = response.json()
+        choice = data.get("choices", [{}])[0]
+        message = choice.get("message", {}).get("content", "")
+        return str(message)
+
+
+class MockClient(LLMClient):
+    def __init__(self, cfg: Optional[LLMConfig] = None) -> None:
+        self.cfg = cfg or LLMConfig(DEFAULT_PROVIDER, "mock", "", "", 5, 0.0)
+
+    def complete(self, prompt: str) -> str:  # pragma: no cover - trivial
+        logging.info("Mock LLM utilisé (pas d'appel réseau)")
+        return json.dumps(
+            {
+                "movie_title": None,
+                "content_type": "autre",
+                "language": "unknown",
+                "menu_labels": [],
+                "mapping": {},
+                "confidence": 0.1,
+                "source": "mock",
+            }
+        )
+
+
+def build_client(cfg: LLMConfig) -> LLMClient:
+    provider = cfg.provider.lower()
+    if provider == "ollama":
+        return OllamaClient(cfg)
+    if provider == "openai":
+        return OpenAIClient(cfg)
+    return MockClient(cfg)
+

--- a/dvd-archiver/bin/scan/heuristics.py
+++ b/dvd-archiver/bin/scan/heuristics.py
@@ -1,0 +1,145 @@
+"""Heuristiques pour la détection de structure DVD."""
+from __future__ import annotations
+
+import logging
+from typing import Dict, List
+
+
+DEFAULT_RUNTIME_TOLERANCE = 120.0
+
+
+def detect_main_feature(struct: Dict[str, object], runtime_tol: float = DEFAULT_RUNTIME_TOLERANCE) -> Dict[str, object]:
+    """Détecte le ou les titres principaux selon la durée."""
+
+    titles = struct.get("titles", []) if isinstance(struct, dict) else []
+    if not titles:
+        return {"mode": "unknown", "main_positions": [], "main_runtime": 0.0}
+
+    durations: List[float] = []
+    for title in titles:
+        try:
+            durations.append(float(title.get("runtime_s", 0.0)))
+        except (TypeError, ValueError):
+            durations.append(0.0)
+    if not durations:
+        return {"mode": "unknown", "main_positions": [], "main_runtime": 0.0}
+
+    max_runtime = max(durations)
+    main_positions = [idx for idx, value in enumerate(durations) if abs(value - max_runtime) <= runtime_tol]
+
+    if len(main_positions) > 1:
+        mode = "series"
+    else:
+        mode = "single"
+
+    return {
+        "mode": mode,
+        "main_positions": main_positions,
+        "main_runtime": max_runtime,
+    }
+
+
+def _title_key(position: int) -> str:
+    return f"title_{position + 1}"
+
+
+def map_menu_labels_to_titles(
+    normalized_labels: Dict[str, object],
+    structure: Dict[str, object],
+    runtime_tol: float = DEFAULT_RUNTIME_TOLERANCE,
+    min_conf: float = 0.5,
+) -> Dict[str, str]:
+    """Associe les labels détectés aux titres connus."""
+
+    titles = structure.get("titles", []) if isinstance(structure, dict) else []
+    if not titles:
+        return {}
+
+    categories = normalized_labels.get("categories", {}) if isinstance(normalized_labels, dict) else {}
+    if not isinstance(categories, dict):
+        categories = {}
+
+    main_info = detect_main_feature(structure, runtime_tol)
+    main_positions: List[int] = list(main_info.get("main_positions", []))
+    main_runtime = float(main_info.get("main_runtime", 0.0))
+
+    mapping: Dict[str, str] = {}
+    for pos, title in enumerate(titles):
+        key = _title_key(pos)
+        runtime = float(title.get("runtime_s", 0.0) or 0.0)
+        label_candidates: List[str] = []
+
+        if pos in main_positions:
+            label_candidates.append("Main Feature")
+            if "chapters" in categories:
+                label_candidates.append("Chapters")
+            if len(main_positions) > 1 and "episodes" in categories:
+                label_candidates.append(f"Episode {pos + 1}")
+        else:
+            if runtime and main_runtime and runtime + runtime_tol < main_runtime:
+                label_candidates.append("Bonus")
+            if "bonus" in categories:
+                label_candidates.append("Bonus")
+
+        if not label_candidates and "episodes" in categories:
+            label_candidates.append(f"Episode {pos + 1}")
+
+        if not label_candidates and runtime and main_runtime and abs(runtime - main_runtime) <= runtime_tol:
+            label_candidates.append("Feature Alt")
+
+        if not label_candidates:
+            continue
+
+        # Filtre selon confiance moyenne
+        entries = [entry for entry in categories.get("bonus", [])] + [entry for entry in categories.get("play", [])]
+        average_conf = None
+        confidences: List[float] = []
+        for entry in entries:
+            conf = entry.get("confidence") if isinstance(entry, dict) else None
+            if conf is not None:
+                try:
+                    confidences.append(float(conf))
+                except (TypeError, ValueError):
+                    continue
+        if confidences:
+            average_conf = sum(confidences) / len(confidences)
+        if average_conf is not None and average_conf < min_conf:
+            logging.debug("Confiance trop faible pour %s (%.2f)", key, average_conf)
+            continue
+
+        mapping[key] = ", ".join(dict.fromkeys(label_candidates))
+
+    return mapping
+
+
+def fallback_payload(
+    normalized_labels: Dict[str, object],
+    structure: Dict[str, object],
+    main_feature: Dict[str, object],
+) -> Dict[str, object]:
+    """Produit un résultat heuristique minimal en absence d'IA."""
+
+    categories = normalized_labels.get("categories", {}) if isinstance(normalized_labels, dict) else {}
+    menu_labels = sorted({label.capitalize() for label in categories.keys()})
+    titles = structure.get("titles", []) if isinstance(structure, dict) else []
+    mode = main_feature.get("mode", "unknown")
+    if mode == "single" and len(titles) == 1:
+        content_type = "film"
+    elif mode == "series" or len(titles) > 1:
+        content_type = "serie"
+    else:
+        content_type = "autre"
+
+    main_positions: List[int] = list(main_feature.get("main_positions", []))
+    mapping = {_title_key(pos): "Main Feature" for pos in main_positions}
+
+    return {
+        "movie_title": None,
+        "content_type": content_type,
+        "language": normalized_labels.get("language", "unknown"),
+        "menu_labels": menu_labels,
+        "mapping": mapping,
+        "confidence": 0.3,
+        "source": "heuristics",
+    }
+

--- a/dvd-archiver/bin/scan/ocr.py
+++ b/dvd-archiver/bin/scan/ocr.py
@@ -1,0 +1,154 @@
+"""Fonctions d'OCR pour le pipeline DVD."""
+from __future__ import annotations
+
+import logging
+import subprocess
+from collections import Counter
+from pathlib import Path
+from typing import Dict, Iterable, List, Sequence
+
+try:
+    import pytesseract  # type: ignore
+    from PIL import Image  # type: ignore
+except ImportError:  # pragma: no cover - dépendances optionnelles
+    pytesseract = None  # type: ignore
+    Image = None  # type: ignore
+
+
+LANG_KEYWORDS = {
+    "fr": ["lecture", "chapit", "bonus", "version", "langue", "sous-titres"],
+    "en": ["play", "chapter", "bonus", "setup", "audio", "subtitle"],
+    "es": ["reproduc", "capít", "idioma", "subtít"],
+    "de": ["wieder", "kapitel", "bonus", "sprache", "untertitel"],
+    "it": ["riprod", "capitol", "bonus", "lingua", "sottotit"],
+}
+
+CANONICAL_LABELS = {
+    "play": ["play", "lecture", "jouer", "start", "film"],
+    "chapters": ["chap", "scene", "scène", "kapitel"],
+    "bonus": ["bonus", "extras", "suppl", "extra"],
+    "audio": ["audio", "lang", "voix", "idioma", "sprache"],
+    "subtitles": ["subtitle", "sous", "subt", "untertitel", "sub"],
+    "episodes": ["episode", "épisode", "capitulo", "episodio"],
+}
+
+
+def extract_menu_frames(
+    vob_paths: Iterable[Path],
+    output_dir: Path,
+    frame_rate: float,
+    frame_max: int,
+    ffmpeg_bin: str,
+) -> List[Path]:
+    """Extrait des frames pour OCR via ffmpeg."""
+
+    extracted: List[Path] = []
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for vob in vob_paths:
+        if not vob.exists():
+            continue
+        stem = vob.stem.replace(" ", "_")
+        target_pattern = output_dir / f"{stem}_%03d.png"
+        for existing in output_dir.glob(f"{stem}_*.png"):
+            try:
+                existing.unlink()
+            except OSError:
+                logging.debug("Impossible de supprimer %s", existing)
+        cmd = [
+            ffmpeg_bin,
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            str(vob),
+            "-vf",
+            f"fps={frame_rate}",
+            "-frames:v",
+            str(frame_max),
+            str(target_pattern),
+        ]
+        logging.info("Extraction ffmpeg: %s", " ".join(cmd))
+        try:
+            subprocess.run(cmd, check=True)
+        except subprocess.CalledProcessError as exc:
+            logging.warning("Extraction ffmpeg échouée pour %s: %s", vob, exc)
+            continue
+        extracted.extend(sorted(output_dir.glob(f"{stem}_*.png")))
+    return extracted
+
+
+def _ocr_with_pytesseract(image_path: Path, langs: str) -> Dict[str, object]:
+    assert pytesseract and Image  # garde pour le type-checker
+    image = Image.open(image_path)
+    data = pytesseract.image_to_data(image, lang=langs, output_type=pytesseract.Output.DICT)
+    text = " ".join(t for t in data.get("text", []) if t.strip())
+    confidences = [int(c) for c in data.get("conf", []) if c not in {"-1", ""}]
+    confidence = (sum(confidences) / (len(confidences) * 100)) if confidences else None
+    return {"text": text.strip(), "frame": str(image_path), "confidence": confidence}
+
+
+def _ocr_with_cli(image_path: Path, langs: str, bin_path: str) -> Dict[str, object]:
+    cmd = [bin_path, str(image_path), "stdout", "-l", langs]
+    logging.debug("Appel tesseract CLI: %s", " ".join(cmd))
+    try:
+        result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+        text = result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        logging.warning("OCR CLI échoué pour %s: %s", image_path, exc)
+        text = ""
+    return {"text": text, "frame": str(image_path), "confidence": None}
+
+
+def ocr_frames(paths: Sequence[str | Path], langs: str, bin_path: str = "tesseract") -> List[Dict[str, object]]:
+    """Effectue l'OCR des images fournies."""
+
+    results: List[Dict[str, object]] = []
+    for raw_path in paths:
+        path = Path(raw_path)
+        if pytesseract and Image:
+            try:
+                results.append(_ocr_with_pytesseract(path, langs))
+                continue
+            except Exception as exc:  # pylint: disable=broad-except
+                logging.warning("OCR pytesseract échoué pour %s: %s", path, exc)
+        results.append(_ocr_with_cli(path, langs, bin_path))
+    return results
+
+
+def detect_language(labels: Sequence[Dict[str, object]]) -> str:
+    counter = Counter()
+    for entry in labels:
+        text = entry.get("text", "")
+        lower = text.lower()
+        for lang, keywords in LANG_KEYWORDS.items():
+            if any(keyword in lower for keyword in keywords):
+                counter[lang] += 1
+    if not counter:
+        return "unknown"
+    return counter.most_common(1)[0][0]
+
+
+def normalize_labels(labels: Sequence[Dict[str, object]]) -> Dict[str, object]:
+    categories: Dict[str, List[Dict[str, object]]] = {key: [] for key in CANONICAL_LABELS}
+    cleaned: List[Dict[str, object]] = []
+    for entry in labels:
+        text = str(entry.get("text", "")).strip()
+        if not text:
+            continue
+        normalized = {
+            "text": text,
+            "frame": entry.get("frame"),
+            "confidence": entry.get("confidence"),
+        }
+        cleaned.append(normalized)
+        lower = text.lower()
+        for canonical, keywords in CANONICAL_LABELS.items():
+            if any(keyword in lower for keyword in keywords):
+                categories.setdefault(canonical, []).append(normalized)
+    language = detect_language(cleaned)
+    return {
+        "raw": cleaned,
+        "categories": {k: v for k, v in categories.items() if v},
+        "language": language,
+    }
+

--- a/dvd-archiver/bin/scan/scanner.py
+++ b/dvd-archiver/bin/scan/scanner.py
@@ -1,0 +1,247 @@
+#!/usr/bin/env python3
+"""Orchestrateur de la phase 2 (scan + OCR + IA) du pipeline DVD."""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shlex
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Dict, List
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import ai_analyzer  # noqa: E402
+import heuristics  # noqa: E402
+import ocr  # noqa: E402
+import techparse  # noqa: E402
+import writers  # noqa: E402
+
+
+CONFIG_FILE = Path("/etc/dvdarchiver.conf")
+
+
+def load_env_from_conf(path: Path = CONFIG_FILE) -> None:
+    """Charge les variables du fichier de configuration dans l'environnement."""
+
+    if not path.exists():
+        return
+
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        if not key or key.startswith("#"):
+            continue
+        if key in os.environ:
+            continue
+        value = value.strip()
+        if value:
+            try:
+                parts = shlex.split(value, posix=True)
+            except ValueError:
+                parts = [value.strip("\"\'")]
+            if len(parts) == 0:
+                final = ""
+            elif len(parts) == 1:
+                final = parts[0]
+            else:
+                final = " ".join(parts)
+        else:
+            final = ""
+        os.environ.setdefault(key, final)
+
+
+@dataclass
+class Config:
+    ffmpeg_bin: str = "ffmpeg"
+    ffprobe_bin: str = "ffprobe"
+    ocr_bin: str = "tesseract"
+    ocr_langs: str = "eng+fra+spa+ita+deu"
+    frame_rate_menu_fps: float = 1.0
+    frame_max_menu: int = 30
+    menu_vob_patterns: List[str] = field(default_factory=lambda: ["VIDEO_TS.VOB", "VTS_*_0.VOB"])
+    struct_fallback_from_mkv: bool = True
+    runtime_tolerance_sec: int = 120
+    confidence_min: float = 0.5
+    llm_enable: bool = True
+    layout_version: str = "1.0"
+
+    @classmethod
+    def from_env(cls) -> "Config":
+        patterns = os.environ.get("MENU_VOB_GLOB", "VIDEO_TS.VOB VTS_*_0.VOB").split()
+        return cls(
+            ffmpeg_bin=os.environ.get("FFMPEG_BIN", "ffmpeg"),
+            ffprobe_bin=os.environ.get("FFPROBE_BIN", "ffprobe"),
+            ocr_bin=os.environ.get("OCR_BIN", "tesseract"),
+            ocr_langs=os.environ.get("OCR_LANGS", "eng+fra+spa+ita+deu"),
+            frame_rate_menu_fps=float(os.environ.get("FRAME_RATE_MENU_FPS", "1")),
+            frame_max_menu=int(os.environ.get("FRAME_MAX_MENU", "30")),
+            menu_vob_patterns=patterns,
+            struct_fallback_from_mkv=os.environ.get("STRUCT_FALLBACK_FROM_MKV", "1") == "1",
+            runtime_tolerance_sec=int(os.environ.get("RUNTIME_TOLERANCE_SEC", "120")),
+            confidence_min=float(os.environ.get("CONFIDENCE_MIN", "0.5")),
+            llm_enable=os.environ.get("LLM_ENABLE", "1") == "1",
+            layout_version=os.environ.get("ARCHIVE_LAYOUT_VERSION", "1.0"),
+        )
+
+
+class ScanError(Exception):
+    """Erreur bloquante lors du scan."""
+
+
+def setup_logging() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        handlers=[logging.StreamHandler(sys.stdout)],
+    )
+
+
+def load_fingerprint(disc_dir: Path) -> Dict[str, object]:
+    fingerprint_path = disc_dir / "tech" / "fingerprint.json"
+    if fingerprint_path.exists():
+        try:
+            return json.loads(fingerprint_path.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError) as exc:
+            logging.warning("Impossible de lire fingerprint.json: %s", exc)
+    return {}
+
+
+def list_menu_vobs(raw_dir: Path, config: Config) -> List[Path]:
+    matches: List[Path] = []
+    for pattern in config.menu_vob_patterns:
+        matches.extend(sorted(raw_dir.glob(pattern)))
+    return matches
+
+
+def main() -> int:
+    start_total = time.time()
+    load_env_from_conf()
+    setup_logging()
+    config = Config.from_env()
+
+    disc_dir_env = os.environ.get("DISC_DIR")
+    if not disc_dir_env:
+        logging.error("DISC_DIR non défini dans l'environnement")
+        return 1
+
+    disc_dir = Path(disc_dir_env).resolve()
+    logging.info("Démarrage du scan pour %s", disc_dir)
+
+    if not disc_dir.exists():
+        logging.error("Le répertoire disque %s est introuvable", disc_dir)
+        return 1
+
+    metadata_path = disc_dir / "meta" / "metadata_ia.json"
+    if metadata_path.exists():
+        logging.info("metadata_ia.json déjà présent, arrêt (idempotent)")
+        return 0
+
+    (disc_dir / "meta").mkdir(parents=True, exist_ok=True)
+
+    structure_path = disc_dir / "tech" / "structure.lsdvd.yml"
+    structure: Dict[str, object] = {}
+    if structure_path.exists():
+        structure = techparse.parse_lsdvd(structure_path)
+
+    if not structure and config.struct_fallback_from_mkv:
+        mkv_dir = disc_dir / "mkv"
+        if mkv_dir.exists():
+            logging.info("Structure vide, fallback mkvmerge")
+            structure = techparse.probe_mkv_titles(mkv_dir)
+
+    fingerprint = load_fingerprint(disc_dir)
+
+    raw_dir = disc_dir / "raw"
+    frame_paths: List[Path] = []
+    if raw_dir.exists():
+        vob_paths = list_menu_vobs(raw_dir, config)
+        if vob_paths:
+            frame_paths = ocr.extract_menu_frames(
+                vob_paths=vob_paths,
+                output_dir=disc_dir / "meta" / "ocr_frames",
+                frame_rate=config.frame_rate_menu_fps,
+                frame_max=config.frame_max_menu,
+                ffmpeg_bin=config.ffmpeg_bin,
+            )
+        else:
+            logging.info("Aucun VOB de menu détecté")
+    else:
+        logging.info("Répertoire raw/ absent, extraction des menus ignorée")
+
+    ocr_results: List[Dict[str, object]] = []
+    normalized_labels: Dict[str, object] = {"raw": [], "categories": {}, "language": "unknown"}
+    if frame_paths:
+        logging.info("OCR sur %d frames", len(frame_paths))
+        try:
+            ocr_results = ocr.ocr_frames(frame_paths, config.ocr_langs, bin_path=config.ocr_bin)
+            normalized_labels = ocr.normalize_labels(ocr_results)
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error("Erreur OCR: %s", exc)
+    else:
+        logging.info("Aucune frame extraite, OCR ignoré")
+
+    main_feature = heuristics.detect_main_feature(
+        structure,
+        runtime_tol=config.runtime_tolerance_sec,
+    )
+    mapping = heuristics.map_menu_labels_to_titles(
+        normalized_labels=normalized_labels,
+        structure=structure,
+        runtime_tol=config.runtime_tolerance_sec,
+        min_conf=config.confidence_min,
+    )
+
+    logging.info("Heuristique principale: %s", main_feature)
+
+    ia_payload: Dict[str, object] | None = None
+    if config.llm_enable:
+        try:
+            ia_payload = ai_analyzer.infer_structure(
+                ocr_texts=ocr_results,
+                normalized_labels=normalized_labels,
+                struct=structure,
+                fingerprint=fingerprint,
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            logging.error("Erreur IA: %s", exc)
+    else:
+        logging.info("LLM désactivé, heuristiques uniquement")
+
+    if not ia_payload:
+        ia_payload = heuristics.fallback_payload(normalized_labels, structure, main_feature)
+
+    try:
+        writers.write_metadata_json(
+            out_path=metadata_path,
+            disc_uid=disc_dir.name,
+            layout_version=config.layout_version,
+            struct=structure,
+            labels=normalized_labels,
+            mapping=mapping,
+            ia_payload=ia_payload,
+            ocr_results=ocr_results,
+            fingerprint=fingerprint,
+            total_time=time.time() - start_total,
+            llm_enabled=config.llm_enable,
+        )
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.error("Écriture de metadata_ia.json échouée: %s", exc)
+        return 1
+
+    logging.info("metadata_ia.json généré pour %s en %.2fs", disc_dir.name, time.time() - start_total)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dvd-archiver/bin/scan/techparse.py
+++ b/dvd-archiver/bin/scan/techparse.py
@@ -1,0 +1,102 @@
+"""Parsing technique des disques."""
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from typing import Dict, List
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - dépendance optionnelle
+    yaml = None  # type: ignore
+
+
+def _parse_runtime(value: object) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        parts = value.strip().split(":")
+        try:
+            parts = [float(p) for p in parts]
+        except ValueError:
+            return 0.0
+        if len(parts) == 3:
+            hours, minutes, seconds = parts
+            return hours * 3600 + minutes * 60 + seconds
+        if len(parts) == 2:
+            minutes, seconds = parts
+            return minutes * 60 + seconds
+        if len(parts) == 1:
+            return parts[0]
+    return 0.0
+
+
+def parse_lsdvd(path: Path) -> Dict[str, object]:
+    if not path.exists():
+        logging.debug("structure.lsdvd.yml absent: %s", path)
+        return {}
+    if yaml is None:
+        logging.warning("PyYAML non disponible, impossible de parser %s", path)
+        return {}
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    except Exception as exc:  # pylint: disable=broad-except
+        logging.warning("Lecture YAML échouée pour %s: %s", path, exc)
+        return {}
+
+    titles_raw = data.get("title", [])
+    titles: List[Dict[str, object]] = []
+    for idx, title in enumerate(titles_raw):
+        runtime = _parse_runtime(title.get("length"))
+        chapters = len(title.get("chapter", []))
+        audio_langs = [track.get("langcode") for track in title.get("audio", []) if track.get("langcode")]
+        sub_langs = [track.get("langcode") for track in title.get("subp", []) if track.get("langcode")]
+        angles = len(title.get("angles", [])) if isinstance(title.get("angles"), list) else 0
+        titles.append(
+            {
+                "index": title.get("ix", idx),
+                "runtime_s": runtime,
+                "chapters": chapters,
+                "audio_langs": audio_langs,
+                "sub_langs": sub_langs,
+                "angles": angles,
+            }
+        )
+    return {"source": "lsdvd", "titles": titles}
+
+
+def probe_mkv_titles(mkv_dir: Path) -> Dict[str, object]:
+    titles: List[Dict[str, object]] = []
+    for mkv_file in sorted(mkv_dir.glob("*.mkv")):
+        cmd = ["mkvmerge", "-J", str(mkv_file)]
+        logging.info("Analyse mkvmerge: %s", " ".join(cmd))
+        try:
+            result = subprocess.run(cmd, check=True, capture_output=True, text=True)
+            data = json.loads(result.stdout)
+        except (subprocess.CalledProcessError, json.JSONDecodeError) as exc:
+            logging.warning("mkvmerge échoué pour %s: %s", mkv_file, exc)
+            continue
+        container = data.get("container", {}).get("properties", {})
+        duration_ns = container.get("duration")
+        if duration_ns is None:
+            runtime = 0.0
+        else:
+            runtime = float(duration_ns) / 1e9
+        audio_langs = [track.get("properties", {}).get("language") for track in data.get("tracks", []) if track.get("type") == "audio"]
+        sub_langs = [track.get("properties", {}).get("language") for track in data.get("tracks", []) if track.get("type") == "subtitles"]
+        titles.append(
+            {
+                "index": mkv_file.stem,
+                "runtime_s": runtime,
+                "chapters": len(container.get("chapters", [])),
+                "audio_langs": [lang for lang in audio_langs if lang],
+                "sub_langs": [lang for lang in sub_langs if lang],
+                "angles": 0,
+            }
+        )
+    if not titles:
+        return {}
+    return {"source": "mkvmerge", "titles": titles}
+

--- a/dvd-archiver/bin/scan/writers.py
+++ b/dvd-archiver/bin/scan/writers.py
@@ -1,0 +1,92 @@
+"""Écriture des métadonnées finales."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, Iterable, List, Optional
+
+
+def _enrich_titles(titles: Iterable[Dict[str, object]]) -> List[Dict[str, object]]:
+    enriched: List[Dict[str, object]] = []
+    for idx, title in enumerate(titles):
+        entry = dict(title)
+        entry.setdefault("id", f"title_{idx + 1}")
+        entry.setdefault("index", title.get("index", idx))
+        entry.setdefault("runtime_s", float(title.get("runtime_s", 0.0) or 0.0))
+        entry.setdefault("chapters", title.get("chapters", 0))
+        entry.setdefault("audio_langs", title.get("audio_langs", []))
+        entry.setdefault("sub_langs", title.get("sub_langs", []))
+        entry.setdefault("angles", title.get("angles", 0))
+        enriched.append(entry)
+    return enriched
+
+
+def _detect_ocr_dir(ocr_results: List[Dict[str, object]]) -> Optional[str]:
+    for entry in ocr_results:
+        frame = entry.get("frame")
+        if frame:
+            return str(Path(frame).resolve().parent)
+    return None
+
+
+def write_metadata_json(
+    out_path: Path,
+    disc_uid: str,
+    layout_version: str,
+    struct: Dict[str, object],
+    labels: Dict[str, object],
+    mapping: Dict[str, str],
+    ia_payload: Dict[str, object],
+    ocr_results: List[Dict[str, object]],
+    fingerprint: Dict[str, object],
+    total_time: float,
+    llm_enabled: bool,
+) -> None:
+    """Écrit le fichier metadata_ia.json avec les informations consolidées."""
+
+    titles = _enrich_titles(struct.get("titles", []) if isinstance(struct, dict) else [])
+    inferred_title = ia_payload.get("movie_title") if isinstance(ia_payload, dict) else None
+    inferred_type = ia_payload.get("content_type") if isinstance(ia_payload, dict) else "autre"
+    inferred_lang = ia_payload.get("language") if isinstance(ia_payload, dict) else labels.get("language", "unknown")
+    inferred_conf = ia_payload.get("confidence") if isinstance(ia_payload, dict) else 0.0
+    provider = ia_payload.get("source") if isinstance(ia_payload, dict) else "heuristics"
+    model = ia_payload.get("model") if isinstance(ia_payload, dict) else None
+
+    payload = {
+        "disc_uid": disc_uid,
+        "layout_version": layout_version,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "processing_time_sec": round(total_time, 3),
+        "inferred": {
+            "title": inferred_title,
+            "content_type": inferred_type,
+            "language": inferred_lang,
+            "confidence": inferred_conf,
+            "source": provider,
+            "model": model,
+        },
+        "structure": {
+            "source": struct.get("source", "unknown") if isinstance(struct, dict) else "unknown",
+            "titles": titles,
+        },
+        "menus": {
+            "labels": labels,
+            "frames_used": [entry.get("frame") for entry in ocr_results if entry.get("frame")],
+        },
+        "mapping": mapping,
+        "fingerprint": fingerprint,
+        "sources": {
+            "tech": struct.get("source", "unknown") if isinstance(struct, dict) else "unknown",
+            "ocr_dir": _detect_ocr_dir(ocr_results),
+            "llm": {
+                "enabled": llm_enabled,
+                "provider": provider,
+                "model": model,
+            },
+        },
+    }
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+

--- a/dvd-archiver/bin/scan_consumer.sh
+++ b/dvd-archiver/bin/scan_consumer.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/dvdarchiver.conf"
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck disable=SC1091
+  source "$CONFIG_FILE"
+fi
+
+DEST="${DEST:-/mnt/media_master}"
+SCAN_QUEUE_DIR="${SCAN_QUEUE_DIR:-/var/spool/dvdarchiver-scan}"
+SCAN_LOG_DIR="${SCAN_LOG_DIR:-/var/log/dvdarchiver-scan}"
+SCAN_SCANNER_BIN="${SCAN_SCANNER_BIN:-/usr/local/bin/scan/scanner.py}"
+PYTHON_BIN="${PYTHON_BIN:-python3}"
+
+log() {
+  printf '[scan_consumer] %s\n' "$*"
+}
+
+mkdir -p "$SCAN_QUEUE_DIR" "$SCAN_LOG_DIR"
+
+process_job() {
+  local job="$1"
+  local status suffix disc_dir log_file ts result_file
+
+  # shellcheck disable=SC1090
+  source "$job"
+
+  disc_dir="${DISC_DIR:-}"
+  if [[ -z "$disc_dir" ]]; then
+    log "Job $job invalide: DISC_DIR manquant"
+    suffix="err"
+    ts="$(date -Is)"
+    result_file="${job%.job}.${suffix}"
+    {
+      cat "$job"
+      echo "STATUS=ERREUR"
+      echo "TIMESTAMP=$ts"
+      echo "MESSAGE=DISC_DIR absent"
+    } >"$result_file"
+    rm -f "$job"
+    return
+  fi
+
+  if [[ ! -d "$disc_dir" ]]; then
+    log "Répertoire disque introuvable: $disc_dir"
+    suffix="err"
+    ts="$(date -Is)"
+    result_file="${job%.job}.${suffix}"
+    {
+      cat "$job"
+      echo "STATUS=ERREUR"
+      echo "TIMESTAMP=$ts"
+      echo "MESSAGE=DISC_DIR introuvable"
+    } >"$result_file"
+    rm -f "$job"
+    return
+  fi
+
+  if [[ -f "$disc_dir/meta/metadata_ia.json" ]]; then
+    log "Déjà traité: $disc_dir"
+    suffix="done"
+    ts="$(date -Is)"
+    result_file="${job%.job}.${suffix}"
+    {
+      cat "$job"
+      echo "STATUS=EXISTANT"
+      echo "TIMESTAMP=$ts"
+      echo "MESSAGE=metadata déjà présent"
+    } >"$result_file"
+    rm -f "$job"
+    return
+  fi
+
+  ts="$(date +%Y%m%dT%H%M%S)"
+  log_file_name="scan-$(basename "$disc_dir")-${ts}.log"
+  log_file="$SCAN_LOG_DIR/$log_file_name"
+
+  log "Traitement $disc_dir (log: $log_file)"
+  export DISC_DIR="$disc_dir"
+
+  set +e
+  "$PYTHON_BIN" "$SCAN_SCANNER_BIN" 2>&1 | tee -a "$log_file"
+  status=${PIPESTATUS[0]}
+  set -e
+
+  if [[ $status -eq 0 ]]; then
+    suffix="done"
+    log "Job terminé pour $disc_dir"
+  else
+    suffix="err"
+    log "Job en erreur ($status) pour $disc_dir"
+  fi
+
+  result_file="${job%.job}.${suffix}"
+  {
+    cat "$job"
+    echo "STATUS=$suffix"
+    echo "EXIT_CODE=$status"
+    echo "LOG_FILE=$log_file"
+    echo "TIMESTAMP=$(date -Is)"
+  } >"$result_file"
+  rm -f "$job"
+}
+
+shopt -s nullglob
+jobs=("$SCAN_QUEUE_DIR"/SCAN_*.job)
+shopt -u nullglob
+
+if [[ ${#jobs[@]} -eq 0 ]]; then
+  log "Aucun job à traiter"
+  exit 0
+fi
+
+for job in "${jobs[@]}"; do
+  process_job "$job"
+done

--- a/dvd-archiver/bin/scan_enqueue.sh
+++ b/dvd-archiver/bin/scan_enqueue.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+CONFIG_FILE="/etc/dvdarchiver.conf"
+if [[ -f "$CONFIG_FILE" ]]; then
+  # shellcheck disable=SC1091
+  source "$CONFIG_FILE"
+fi
+
+DEST="${DEST:-/mnt/media_master}"
+SCAN_QUEUE_DIR="${SCAN_QUEUE_DIR:-/var/spool/dvdarchiver-scan}"
+
+log() {
+  printf '[scan_enqueue] %s\n' "$*"
+}
+
+usage() {
+  cat <<USAGE >&2
+Usage: $0 <DISC_DIR>
+USAGE
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 1
+fi
+
+disc_dir="$1"
+if [[ ! -d "$disc_dir" ]]; then
+  echo "Répertoire disque introuvable: $disc_dir" >&2
+  exit 1
+fi
+
+if ! mkdir -p "$SCAN_QUEUE_DIR"; then
+  echo "Impossible de créer $SCAN_QUEUE_DIR" >&2
+  exit 1
+fi
+
+disc_dir="$(cd "$disc_dir" && pwd)"
+meta_json="$disc_dir/meta/metadata_ia.json"
+if [[ -f "$meta_json" ]]; then
+  log "Déjà traité ($meta_json)"
+  exit 0
+fi
+
+# Vérifie si un job existe déjà pour ce disque
+shopt -s nullglob
+for job in "$SCAN_QUEUE_DIR"/SCAN_*.job; do
+  if grep -q "^DISC_DIR=\"$disc_dir\"" "$job"; then
+    log "Job déjà présent: $job"
+    shopt -u nullglob
+    exit 0
+  fi
+done
+shopt -u nullglob
+
+# Génère un suffixe aléatoire
+rand="$(LC_ALL=C tr -dc 'A-Za-z0-9' </dev/urandom | head -c 6 || date +%s)"
+ts="$(date +%s)"
+job_file="$SCAN_QUEUE_DIR/SCAN_${ts}_${rand}.job"
+
+tmp_job="${job_file}.tmp"
+cat <<JOB >"$tmp_job"
+DISC_DIR="$disc_dir"
+ACTION="SCAN"
+JOB
+mv "$tmp_job" "$job_file"
+log "Job créé: $job_file"

--- a/dvd-archiver/docs/SCAN_PIPELINE.md
+++ b/dvd-archiver/docs/SCAN_PIPELINE.md
@@ -1,0 +1,70 @@
+# Phase 2 – Scan + OCR + IA
+
+Cette phase analyse les disques déjà rippés pour produire `meta/metadata_ia.json` en combinant informations techniques, OCR des menus et raisonnement IA (LLM par défaut via Ollama / Qwen2.5-14B-Instruct Q4).
+
+## Flux global
+
+```text
+[scan_enqueue.sh] -> file d'attente (${SCAN_QUEUE_DIR}) -> [scan_consumer.sh] -> scanner.py -> meta/metadata_ia.json
+```
+
+1. **Enqueue** : `scan_enqueue.sh` ajoute un job par disque à scanner (idempotent, ignorer si `meta/metadata_ia.json` existe).
+2. **Consumer** : `scan_consumer.sh` lit la file, appelle `scanner.py` et journalise dans `${SCAN_LOG_DIR}`.
+3. **Scanner** : `scanner.py` orchestre parsing technique (`techparse`), extraction/ocr des menus, heuristiques et appel IA (`ai_analyzer`).
+4. **Écriture** : `writers.write_metadata_json` consolide les données, y compris la provenance (LLM utilisé, temps de traitement, etc.).
+
+## Dépendances
+
+- Python ≥ 3.10 (modules `requests`, `pytesseract`, `Pillow`, `PyYAML`).
+- Binaires : `tesseract-ocr`, `ffmpeg`, `ffprobe`, `lsdvd`, `mkvmerge`.
+- Ollama (service `ollama.service`) pour tirer/servir `qwen2.5:14b-instruct-q4_K_M` (configurable).
+
+## Installation rapide
+
+```bash
+cd dvd-archiver
+chmod +x install.sh
+sudo ./install.sh
+```
+
+Le script :
+
+- vérifie les dépendances,
+- installe Ollama si besoin puis `ollama pull qwen2.5:14b-instruct-q4_K_M`,
+- copie les scripts dans `/usr/local/bin/` (`scan_enqueue.sh`, `scan_consumer.sh`, `scan/scanner.py`, ...),
+- crée les répertoires `${DEST}`, `${SCAN_QUEUE_DIR}`, `${SCAN_LOG_DIR}` avec valeurs par défaut (`DEST=/mnt/media_master`),
+- installe `/etc/dvdarchiver.conf` si absent et active `dvdarchiver-scan-consumer.path`.
+
+## Configuration
+
+Toutes les valeurs sont lues dans `/etc/dvdarchiver.conf` (copie de `etc/dvdarchiver.conf.sample`). Extraits importants :
+
+```bash
+DEST="/mnt/media_master"
+SCAN_QUEUE_DIR="/var/spool/dvdarchiver-scan"
+SCAN_LOG_DIR="/var/log/dvdarchiver-scan"
+LLM_PROVIDER="ollama"
+LLM_MODEL="qwen2.5:14b-instruct-q4_K_M"
+LLM_ENDPOINT="http://127.0.0.1:11434"
+LLM_ENABLE=1
+```
+
+Surcharger via variables d'environnement au besoin (`LLM_PROVIDER`, `LLM_MODEL`, `LLM_ENDPOINT`, `LLM_API_KEY`, etc.). Mettre `LLM_ENABLE=0` pour désactiver l'IA et n'utiliser que les heuristiques.
+
+## Test rapide
+
+```bash
+scan_enqueue.sh "${DEST}/<DISC_UID>"
+journalctl -u dvdarchiver-scan-consumer.service -f
+cat "${DEST}/<DISC_UID>/meta/metadata_ia.json"
+```
+
+Le premier appel place un job (si aucun `metadata_ia.json`). `journalctl` permet de suivre l'exécution, puis vérifier le fichier généré.
+
+## Dépannage
+
+- **Pas de menus VOB (`raw/`)** : le scanner basculera sur `STRUCT_FALLBACK_FROM_MKV=1` et utilisera `mkvmerge -J` pour récupérer les durées.
+- **LLM indisponible** : si Ollama ou le modèle ne répond pas, l'analyse retombe sur `heuristics.fallback_payload` avec un marquage `source="heuristics"`.
+- **Tesseract absent** : `install.sh` avertit et l'OCR retournera un texte vide, mais le pipeline continue avec heuristiques/IA.
+- **File saturée** : `scan_consumer.sh` garde une trace `.done`/`.err` pour chaque job et envoie la sortie dans `${SCAN_LOG_DIR}` + journal systemd.
+

--- a/dvd-archiver/etc/dvdarchiver.conf.sample
+++ b/dvd-archiver/etc/dvdarchiver.conf.sample
@@ -1,0 +1,33 @@
+# Configuration DVD Archiver - Phase 2 Scan & IA
+# Copiez ce fichier vers /etc/dvdarchiver.conf et ajustez les valeurs si nécessaire.
+
+# --- Phase 1 (rappel utile) ---
+DEST="/mnt/media_master"
+
+# --- Phase 2: Scan & OCR ---
+SCAN_QUEUE_DIR="/var/spool/dvdarchiver-scan"
+SCAN_LOG_DIR="/var/log/dvdarchiver-scan"
+SCAN_TRIGGER_GLOB="${DEST:-/mnt/media_master}/*/mkv/title*.mkv"
+
+# OCR / vidéo
+FFMPEG_BIN="ffmpeg"
+FFPROBE_BIN="ffprobe"
+OCR_BIN="tesseract"
+OCR_LANGS="eng+fra+spa+ita+deu"
+FRAME_RATE_MENU_FPS=1
+FRAME_MAX_MENU=30
+MENU_VOB_GLOB="VIDEO_TS.VOB VTS_*_0.VOB"
+STRUCT_FALLBACK_FROM_MKV=1
+
+# Heuristiques & seuils
+RUNTIME_TOLERANCE_SEC=120
+CONFIDENCE_MIN=0.50
+
+# --- IA / LLM (par défaut : Qwen2.5-14B via Ollama) ---
+LLM_ENABLE=1
+LLM_PROVIDER="ollama"
+LLM_ENDPOINT="http://127.0.0.1:11434"
+LLM_MODEL="qwen2.5:14b-instruct-q4_K_M"
+LLM_TEMPERATURE=0.2
+LLM_TIMEOUT_SEC=3600
+LLM_API_KEY=""

--- a/dvd-archiver/install.sh
+++ b/dvd-archiver/install.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PREFIX="${PREFIX:-/usr/local}"
+BINDIR="${PREFIX}/bin"
+SCANDIR="${BINDIR}/scan"
+SYSTEMD_DIR="/etc/systemd/system"
+CONFIG_FILE="/etc/dvdarchiver.conf"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_SAMPLE="${SCRIPT_DIR}/etc/dvdarchiver.conf.sample"
+
+log() { printf '[install] %s\n' "$*"; }
+warn() { printf '[install][WARN] %s\n' "$*" >&2; }
+error() { printf '[install][ERREUR] %s\n' "$*" >&2; }
+
+check_dep() {
+  local bin="$1"
+  if command -v "$bin" >/dev/null 2>&1; then
+    log "Dépendance présente: $bin"
+  else
+    warn "Dépendance manquante: $bin"
+  fi
+}
+
+install_ollama() {
+  if command -v ollama >/dev/null 2>&1; then
+    log "Ollama déjà installé"
+    return
+  fi
+  warn "Ollama absent, tentative d'installation"
+  if ! command -v curl >/dev/null 2>&1; then
+    warn "curl indisponible, installez Ollama manuellement: https://ollama.ai"
+    return
+  fi
+  set +e
+  curl -fsSL https://ollama.ai/install.sh | sh
+  local rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    warn "Installation Ollama échouée (code $rc). Installez-le manuellement."
+    return
+  fi
+  if command -v systemctl >/dev/null 2>&1; then
+    if ! systemctl enable --now ollama >/dev/null 2>&1; then
+      warn "Impossible d'activer le service ollama (poursuite malgré tout)"
+    else
+      log "Service ollama activé"
+    fi
+  fi
+}
+
+pull_llm_model() {
+  local model="${LLM_MODEL:-qwen2.5:14b-instruct-q4_K_M}"
+  if ! command -v ollama >/dev/null 2>&1; then
+    warn "Ollama indisponible, impossible de tirer le modèle ${model}."
+    warn "Vous pourrez lancer: ollama pull ${model} une fois le service prêt."
+    return
+  fi
+  log "Téléchargement du modèle Ollama (${model})"
+  set +e
+  ollama pull "${model}"
+  local rc=$?
+  set -e
+  if [[ $rc -ne 0 ]]; then
+    warn "Échec du téléchargement du modèle ${model} (code ${rc}). Relancez manuellement."
+  fi
+}
+
+copy_scripts() {
+  install -d "${BINDIR}" "${SCANDIR}"
+  install -m 0755 "${SCRIPT_DIR}/bin/scan_enqueue.sh" "${BINDIR}/scan_enqueue.sh"
+  install -m 0755 "${SCRIPT_DIR}/bin/scan_consumer.sh" "${BINDIR}/scan_consumer.sh"
+  for module in "${SCRIPT_DIR}"/bin/scan/*.py; do
+    local mode=0644
+    [[ $(basename "${module}") == "scanner.py" ]] && mode=0755
+    install -m "${mode}" "${module}" "${SCANDIR}/$(basename "${module}")"
+  done
+  log "Scripts installés dans ${BINDIR} et ${SCANDIR}"
+}
+
+install_config() {
+  if [[ ! -f "${CONFIG_FILE}" ]]; then
+    install -Dm0644 "${CONFIG_SAMPLE}" "${CONFIG_FILE}"
+    log "Configuration initiale copiée vers ${CONFIG_FILE}"
+  else
+    log "Configuration existante détectée (${CONFIG_FILE}), pas d'écrasement"
+    diff -u "${CONFIG_SAMPLE}" "${CONFIG_FILE}" || true
+  fi
+  # shellcheck disable=SC1091
+  if [[ -f "${CONFIG_FILE}" ]]; then source "${CONFIG_FILE}"; fi
+  DEST="${DEST:-/mnt/media_master}"
+  SCAN_QUEUE_DIR="${SCAN_QUEUE_DIR:-/var/spool/dvdarchiver-scan}"
+  SCAN_LOG_DIR="${SCAN_LOG_DIR:-/var/log/dvdarchiver-scan}"
+  mkdir -p "${DEST}" "${SCAN_QUEUE_DIR}" "${SCAN_LOG_DIR}"
+  log "Répertoires prêts: DEST=${DEST}, QUEUE=${SCAN_QUEUE_DIR}, LOG=${SCAN_LOG_DIR}"
+}
+
+install_systemd() {
+  install -Dm0644 "${SCRIPT_DIR}/systemd/dvdarchiver-scan-consumer.service" "${SYSTEMD_DIR}/dvdarchiver-scan-consumer.service"
+  install -Dm0644 "${SCRIPT_DIR}/systemd/dvdarchiver-scan-consumer.path" "${SYSTEMD_DIR}/dvdarchiver-scan-consumer.path"
+  if command -v systemctl >/dev/null 2>&1; then
+    systemctl daemon-reload
+    if ! systemctl enable --now dvdarchiver-scan-consumer.path >/dev/null 2>&1; then
+      warn "Impossible d'activer dvdarchiver-scan-consumer.path. Activez-le manuellement."
+    else
+      log "Path dvdarchiver-scan-consumer activé"
+    fi
+  else
+    warn "systemctl indisponible, installez les unités manuellement"
+  fi
+}
+
+print_summary() {
+  cat <<SUMMARY
+--- Récapitulatif ---
+Binaires installés dans : ${BINDIR}
+Scripts Python dans : ${SCANDIR}
+Configuration : ${CONFIG_FILE}
+Destination : ${DEST:-/mnt/media_master}
+File de scan : ${SCAN_QUEUE_DIR:-/var/spool/dvdarchiver-scan}
+Logs : ${SCAN_LOG_DIR:-/var/log/dvdarchiver-scan}
+LLM : provider=${LLM_PROVIDER:-ollama} modèle=${LLM_MODEL:-qwen2.5:14b-instruct-q4_K_M}
+
+Test rapide :
+  scan_enqueue.sh "${DEST:-/mnt/media_master}/<DISC_UID>"
+  journalctl -u dvdarchiver-scan-consumer.service -f
+SUMMARY
+}
+
+main() {
+  log "Installation Phase 2 (scan + OCR + IA)"
+
+  check_dep python3
+  check_dep pip3
+  check_dep tesseract
+  check_dep ffmpeg
+  check_dep ffprobe
+  check_dep lsdvd
+  check_dep mkvmerge
+
+  install_ollama
+  # Peut définir LLM_MODEL via configuration après sourcing
+  if [[ -f "${CONFIG_FILE}" ]]; then
+    # shellcheck disable=SC1091
+    source "${CONFIG_FILE}"
+  fi
+  pull_llm_model || true
+
+  copy_scripts
+  install_config
+  install_systemd
+
+  print_summary
+}
+
+main "$@"

--- a/dvd-archiver/systemd/README-systemd-scan.md
+++ b/dvd-archiver/systemd/README-systemd-scan.md
@@ -1,0 +1,50 @@
+# Unités systemd – Phase 2 (Scan + IA)
+
+Ces unités assurent la consommation de la file de scan et l'analyse IA des disques rippés.
+
+## Fichiers
+
+- `dvdarchiver-scan-consumer.service` : lance `scan_consumer.sh` qui dépile les jobs et appelle `scanner.py`.
+- `dvdarchiver-scan-consumer.path` : surveille le motif configuré (`SCAN_TRIGGER_GLOB`) et démarre le service dès qu'un MKV est présent.
+
+Les deux unités attendent que la configuration `/etc/dvdarchiver.conf` fournisse les chemins (file, destination, modèle IA, etc.).
+
+## Installation
+
+Après copie dans `/etc/systemd/system/` (ou via `install.sh`), rechargez systemd puis activez le path :
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now dvdarchiver-scan-consumer.path
+```
+
+Le `.path` déclenchera automatiquement le service quand un fichier correspondant à `SCAN_TRIGGER_GLOB` apparaît.
+
+## Vérification & journaux
+
+Pour vérifier l'état :
+
+```bash
+systemctl status dvdarchiver-scan-consumer.path
+systemctl status dvdarchiver-scan-consumer.service
+```
+
+Suivre les journaux en direct :
+
+```bash
+journalctl -u dvdarchiver-scan-consumer.service -f
+```
+
+Les logs détaillés de chaque traitement sont également écrits dans `${SCAN_LOG_DIR}`.
+
+## Désactivation
+
+Pour désactiver temporairement la phase 2 :
+
+```bash
+sudo systemctl disable --now dvdarchiver-scan-consumer.path
+sudo systemctl stop dvdarchiver-scan-consumer.service
+```
+
+Remettez `LLM_ENABLE=0` dans `/etc/dvdarchiver.conf` pour forcer un mode heuristique sans appels réseau.
+

--- a/dvd-archiver/systemd/dvdarchiver-scan-consumer.path
+++ b/dvd-archiver/systemd/dvdarchiver-scan-consumer.path
@@ -1,0 +1,10 @@
+[Unit]
+Description=DVD Archiver - Surveillance Phase 2 (déclencheur scan)
+
+[Path]
+EnvironmentFile=/etc/dvdarchiver.conf
+PathExistsGlob=${SCAN_TRIGGER_GLOB}
+Unit=dvdarchiver-scan-consumer.service
+
+[Install]
+WantedBy=multi-user.target

--- a/dvd-archiver/systemd/dvdarchiver-scan-consumer.service
+++ b/dvd-archiver/systemd/dvdarchiver-scan-consumer.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=DVD Archiver - Consommateur Phase 2 (scan + IA)
+After=network.target
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/dvdarchiver.conf
+ExecStart=/usr/local/bin/scan_consumer.sh
+Restart=on-failure
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- add a dvd-archiver module that introduces queue scripts and the Python scan pipeline for OCR and IA analysis
- provide an install script that checks dependencies, installs configuration, systemd units, and pulls the Ollama Qwen2.5 14B model by default
- document the Phase 2 workflow and systemd usage with updated samples and configuration defaults

## Testing
- python3 -m compileall dvd-archiver/bin/scan

------
https://chatgpt.com/codex/tasks/task_b_68ebfab0eae483319208be0e1ab49435