### PR TITLE
Add conditional metadata validation and gate MKV builds

### DIFF
--- a/dvd-archiver/bin/scan/validator.py
+++ b/dvd-archiver/bin/scan/validator.py
@@ -1,0 +1,122 @@
+"""Validation des métadonnées IA via Pydantic."""
+from __future__ import annotations
+
+import json
+from typing import Dict, List, Literal, Optional
+
+try:
+    from pydantic import (
+        BaseModel,
+        Field,
+        ValidationError,
+        conint,
+        confloat,
+        constr,
+        model_validator,
+    )
+except ModuleNotFoundError as exc:  # pragma: no cover - dépendance manquante
+    raise RuntimeError(
+        "La dépendance 'pydantic>=2' est requise pour valider les métadonnées. "
+        "Installez-la via 'pip install \"pydantic>=2\"'."
+    ) from exc
+
+ItemType = Literal["main", "episode", "bonus", "trailer"]
+ContentType = Literal["film", "serie", "autre"]
+
+
+class Item(BaseModel):
+    """Description d'un élément extrait du DVD (feature, épisode, bonus...)."""
+
+    type: ItemType
+    title_index: conint(ge=1)
+    runtime_seconds: conint(ge=60)
+    audio_langs: List[str] = Field(default_factory=list)
+    sub_langs: List[str] = Field(default_factory=list)
+    season: Optional[int] = None
+    episode: Optional[int] = None
+    episode_title: Optional[str] = None
+    label: Optional[str] = None
+
+
+class Meta(BaseModel):
+    """Métadonnées globales décrivant un disque et ses contenus."""
+
+    disc_uid: constr(min_length=1)
+    content_type: ContentType
+    movie_title: Optional[str] = None
+    series_title: Optional[str] = None
+    language: constr(min_length=1)
+    year: Optional[int] = None
+    items: List[Item]
+    mapping: Dict[str, str]
+    confidence: confloat(ge=0.0, le=1.0)
+    sources: Dict[str, object] = Field(default_factory=dict)
+    generated_at: Optional[str] = None
+
+    @model_validator(mode="after")
+    def _gate(self) -> "Meta":
+        if not self.items:
+            raise ValueError("items: au moins un élément requis")
+
+        if self.content_type == "film":
+            if self.series_title is not None:
+                raise ValueError("film: series_title doit être null")
+            if not any(item.type == "main" for item in self.items):
+                raise ValueError("film: un item 'main' est requis")
+            if not self.movie_title and float(self.confidence) < 0.70:
+                raise ValueError("film: movie_title absent et confidence < 0.70")
+            mains = [item for item in self.items if item.type == "main"]
+            if not any(f"title_{item.title_index}" in self.mapping for item in mains):
+                raise ValueError("film: mapping doit couvrir le main feature")
+        elif self.content_type == "serie":
+            if not self.series_title:
+                raise ValueError("serie: series_title requis (non vide)")
+            episodes = [item for item in self.items if item.type == "episode"]
+            if not episodes:
+                raise ValueError("serie: au moins un item 'episode' est requis")
+            for episode in episodes:
+                if episode.season is None or episode.episode is None:
+                    raise ValueError("serie: season et episode requis pour chaque 'episode'")
+            missing = [
+                episode
+                for episode in episodes
+                if f"title_{episode.title_index}" not in self.mapping
+            ]
+            if missing:
+                raise ValueError("serie: mapping doit couvrir tous les épisodes")
+            if self.movie_title is not None:
+                raise ValueError("serie: movie_title doit être null")
+        else:  # "autre"
+            if float(self.confidence) < 0.50:
+                raise ValueError("autre: confidence minimale 0.50")
+            if not any(item.type == "main" for item in self.items):
+                bonus_trailer = [
+                    item for item in self.items if item.type in ("bonus", "trailer")
+                ]
+                if len(bonus_trailer) < 2:
+                    raise ValueError("autre: nécessite un main ou ≥2 bonus/trailer")
+
+        return self
+
+
+__all__ = [
+    "ContentType",
+    "Item",
+    "ItemType",
+    "Meta",
+    "ValidationError",
+    "dumps",
+    "validate_payload",
+]
+
+
+def validate_payload(data: Dict[str, object]) -> Meta:
+    """Valide le dictionnaire brut et retourne l'objet `Meta` correspondant."""
+
+    return Meta.model_validate(data)
+
+
+def dumps(meta: Meta) -> str:
+    """Sérialise l'objet `Meta` en JSON formaté."""
+
+    return json.dumps(meta.model_dump(), ensure_ascii=False, indent=2)

--- a/dvd-archiver/bin/scan/writers.py
+++ b/dvd-archiver/bin/scan/writers.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 import json
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Dict
+from typing import Any, Dict
 
 
-def write_metadata_json(out_path: Path, metadata: Dict[str, object]) -> None:
+def write_metadata_json(out_path: Path, metadata: Dict[str, object] | Any) -> None:
     """Écrit le JSON final avec indentation."""
 
-    payload = dict(metadata)
+    if hasattr(metadata, "model_dump"):
+        payload = metadata.model_dump()
+    else:
+        payload = dict(metadata)
     payload.setdefault("generated_at", datetime.now(timezone.utc).isoformat())
     out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(payload, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")

--- a/dvd-archiver/systemd/README-systemd.md
+++ b/dvd-archiver/systemd/README-systemd.md
@@ -9,8 +9,8 @@ Deux couples `.path`/`.service` automatisent les phases 2 et 3 du pipeline.
 
 ## Phase 3 – Build MKV
 
-- `dvdarchiver-mkv-build-consumer.service` : exécute `mkv_build_consumer.sh` pour générer les `.mkv` (validation du JSON, appel MakeMKV, génération optionnelle des `.nfo`).
-- `dvdarchiver-mkv-build-consumer.path` : surveille `${DEST}/*/meta/metadata_ia.json` et déclenche la phase 3 uniquement lorsque la métadonnée est présente.
+- `dvdarchiver-mkv-build-consumer.service` : exécute `mkv_build_consumer.sh` pour générer les `.mkv`. Le script relit et valide systématiquement `meta/metadata_ia.json` via `validator.Meta` avant d'appeler MakeMKV puis, si configuré, de produire les `.nfo`.
+- `dvdarchiver-mkv-build-consumer.path` : surveille `${DEST}/*/meta/metadata_ia.json` et déclenche la phase 3 uniquement lorsque la métadonnée valide est présente.
 
 ## Installation
 

--- a/tests/test_mkv_build_consumer.py
+++ b/tests/test_mkv_build_consumer.py
@@ -1,0 +1,173 @@
+from __future__ import annotations
+
+import json
+import os
+import stat
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("pydantic", minversion="2")
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SCAN_DIR = PROJECT_ROOT / "dvd-archiver" / "bin" / "scan"
+if str(SCAN_DIR) not in sys.path:
+    sys.path.insert(0, str(SCAN_DIR))
+
+import validator  # type: ignore  # noqa: E402
+
+MKV_CONSUMER = PROJECT_ROOT / "dvd-archiver" / "bin" / "mkv_build_consumer.sh"
+
+
+@pytest.fixture()
+def fake_makemkv(tmp_path: Path) -> Path:
+    script = tmp_path / "makemkv"
+    script.write_text(
+        "#!/usr/bin/env bash\n"
+        "set -euo pipefail\n"
+        "out_dir=\"${@: -1}\"\n"
+        "title=\"\"\n"
+        "for arg in \"$@\"; do\n"
+        "  case \"$arg\" in\n"
+        "    title:*) title=\"${arg#title:}\" ;;\n"
+        "  esac\n"
+        "done\n"
+        "if [[ -z \"$title\" ]]; then\n"
+        "  echo 'title index manquant' >&2\n"
+        "  exit 1\n"
+        "fi\n"
+        "mkdir -p \"$out_dir\"\n"
+        "touch \"$out_dir/title_${title}.mkv\"\n",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | stat.S_IEXEC)
+    return script
+
+
+@pytest.fixture()
+def base_env(tmp_path: Path, fake_makemkv: Path) -> dict[str, str]:
+    build_queue = tmp_path / "queue"
+    build_logs = tmp_path / "logs"
+    tmp_dir = tmp_path / "tmp"
+    build_queue.mkdir()
+    build_logs.mkdir()
+    tmp_dir.mkdir()
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "BUILD_QUEUE_DIR": str(build_queue),
+            "BUILD_LOG_DIR": str(build_logs),
+            "TMP_DIR": str(tmp_dir),
+            "PYTHON_BIN": sys.executable,
+            "RAW_BACKUP_DIR": "raw/VIDEO_TS_BACKUP",
+            "MAKEMKV_BIN": str(fake_makemkv),
+            "MAKEMKV_MKV_OPTS": "",
+            "WRITE_NFO": "0",
+            "SCAN_MODULE_DIR": str(SCAN_DIR),
+        }
+    )
+    return env
+
+
+def write_metadata(path: Path, payload: dict[str, object]) -> None:
+    meta = validator.validate_payload(payload)
+    path.write_text(validator.dumps(meta) + "\n", encoding="utf-8")
+
+
+def prepare_disc(tmp_path: Path, name: str) -> Path:
+    disc_dir = tmp_path / name
+    (disc_dir / "meta").mkdir(parents=True)
+    (disc_dir / "raw" / "VIDEO_TS_BACKUP").mkdir(parents=True)
+    return disc_dir
+
+
+def enqueue_job(queue_dir: Path, disc_dir: Path) -> Path:
+    job = queue_dir / f"BUILD_{disc_dir.name}.job"
+    job.write_text(f'DISC_DIR="{disc_dir}"\n', encoding="utf-8")
+    return job
+
+
+def run_consumer(env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["bash", str(MKV_CONSUMER)],
+        check=False,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def test_mkv_build_consumer_generates_files(tmp_path: Path, base_env: dict[str, str]) -> None:
+    env = base_env.copy()
+    queue_dir = Path(env["BUILD_QUEUE_DIR"])
+    disc_dir = prepare_disc(tmp_path, "DISC_VALID")
+    metadata_path = disc_dir / "meta" / "metadata_ia.json"
+    payload = {
+        "disc_uid": disc_dir.name,
+        "content_type": "film",
+        "movie_title": "Film Exemple",
+        "series_title": None,
+        "language": "fr",
+        "year": 2008,
+        "items": [
+            {
+                "type": "main",
+                "title_index": 1,
+                "runtime_seconds": 7200,
+                "audio_langs": ["fr"],
+                "sub_langs": [],
+            }
+        ],
+        "mapping": {"title_1": "Main Feature"},
+        "confidence": 0.9,
+        "sources": {"ocr": None, "tech_dump": None, "llm": {}},
+    }
+    write_metadata(metadata_path, payload)
+    enqueue_job(queue_dir, disc_dir)
+
+    result = run_consumer(env)
+    assert result.returncode == 0
+    done_files = list(queue_dir.glob("*.done"))
+    assert done_files, f"stdout={result.stdout}\nstderr={result.stderr}"
+    mkv_files = list((disc_dir / "mkv").glob("*.mkv"))
+    assert len(mkv_files) == 1
+    assert mkv_files[0].name == "Film Exemple (2008).mkv"
+
+
+def test_mkv_build_consumer_blocks_invalid_json(tmp_path: Path, base_env: dict[str, str]) -> None:
+    env = base_env.copy()
+    queue_dir = Path(env["BUILD_QUEUE_DIR"])
+    disc_dir = prepare_disc(tmp_path, "DISC_INVALID")
+    metadata_path = disc_dir / "meta" / "metadata_ia.json"
+    invalid_payload = {
+        "disc_uid": disc_dir.name,
+        "content_type": "film",
+        "movie_title": None,
+        "series_title": None,
+        "language": "fr",
+        "year": None,
+        "items": [
+            {
+                "type": "main",
+                "title_index": 1,
+                "runtime_seconds": 7200,
+                "audio_langs": ["fr"],
+                "sub_langs": [],
+            }
+        ],
+        "mapping": {},
+        "confidence": 0.2,
+        "sources": {"ocr": None, "tech_dump": None, "llm": {}},
+    }
+    metadata_path.write_text(json.dumps(invalid_payload), encoding="utf-8")
+    enqueue_job(queue_dir, disc_dir)
+
+    result = run_consumer(env)
+    assert result.returncode == 0
+    err_files = list(queue_dir.glob("*.err"))
+    assert err_files, f"stdout={result.stdout}\nstderr={result.stderr}"
+    mkv_files = list((disc_dir / "mkv").glob("*.mkv"))
+    assert not mkv_files

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+
+import pytest
+
+pytest.importorskip("pydantic", minversion="2")
+
+SCAN_DIR = Path(__file__).resolve().parents[1] / "dvd-archiver" / "bin" / "scan"
+if str(SCAN_DIR) not in sys.path:
+    sys.path.insert(0, str(SCAN_DIR))
+
+import validator  # type: ignore  # noqa: E402
+
+
+def base_sources() -> dict[str, object]:
+    return {"ocr": None, "tech_dump": "structure.lsdvd.yml", "llm": {}}
+
+
+def test_validate_film_valid() -> None:
+    payload = {
+        "disc_uid": "DISC001",
+        "content_type": "film",
+        "movie_title": "Film Test",
+        "series_title": None,
+        "language": "fr",
+        "year": 2001,
+        "items": [
+            {
+                "type": "main",
+                "title_index": 1,
+                "runtime_seconds": 5400,
+                "audio_langs": ["fr"],
+                "sub_langs": ["fr"],
+            }
+        ],
+        "mapping": {"title_1": "Main Feature"},
+        "confidence": 0.9,
+        "sources": base_sources(),
+    }
+    meta = validator.validate_payload(payload)
+    assert meta.movie_title == "Film Test"
+    assert meta.items[0].type == "main"
+
+
+def test_validate_film_requires_mapping() -> None:
+    payload = {
+        "disc_uid": "DISC002",
+        "content_type": "film",
+        "movie_title": "Film sans mapping",
+        "series_title": None,
+        "language": "fr",
+        "year": 2005,
+        "items": [
+            {
+                "type": "main",
+                "title_index": 1,
+                "runtime_seconds": 3600,
+                "audio_langs": ["fr"],
+                "sub_langs": [],
+            }
+        ],
+        "mapping": {},
+        "confidence": 0.8,
+        "sources": base_sources(),
+    }
+    with pytest.raises(validator.ValidationError):
+        validator.validate_payload(payload)
+
+
+def test_validate_serie_valid() -> None:
+    payload = {
+        "disc_uid": "DISC003",
+        "content_type": "serie",
+        "movie_title": None,
+        "series_title": "Série Test",
+        "language": "fr",
+        "year": None,
+        "items": [
+            {
+                "type": "episode",
+                "title_index": 1,
+                "season": 1,
+                "episode": 2,
+                "runtime_seconds": 2400,
+                "audio_langs": ["fr"],
+                "sub_langs": ["fr"],
+            }
+        ],
+        "mapping": {"title_1": "Episode 2"},
+        "confidence": 0.75,
+        "sources": base_sources(),
+    }
+    meta = validator.validate_payload(payload)
+    assert meta.series_title == "Série Test"
+    assert meta.items[0].episode == 2
+
+
+def test_validate_serie_missing_episode_details() -> None:
+    payload = {
+        "disc_uid": "DISC004",
+        "content_type": "serie",
+        "movie_title": None,
+        "series_title": "Série Invalide",
+        "language": "fr",
+        "year": None,
+        "items": [
+            {
+                "type": "episode",
+                "title_index": 1,
+                "season": None,
+                "episode": None,
+                "runtime_seconds": 1800,
+                "audio_langs": ["fr"],
+                "sub_langs": [],
+            }
+        ],
+        "mapping": {"title_1": "Episode"},
+        "confidence": 0.6,
+        "sources": base_sources(),
+    }
+    with pytest.raises(validator.ValidationError):
+        validator.validate_payload(payload)
+
+
+def test_validate_autre_rules() -> None:
+    payload = {
+        "disc_uid": "DISC005",
+        "content_type": "autre",
+        "movie_title": None,
+        "series_title": None,
+        "language": "fr",
+        "year": None,
+        "items": [
+            {
+                "type": "bonus",
+                "title_index": 1,
+                "runtime_seconds": 900,
+                "audio_langs": ["fr"],
+                "sub_langs": [],
+            },
+            {
+                "type": "trailer",
+                "title_index": 2,
+                "runtime_seconds": 600,
+                "audio_langs": ["fr"],
+                "sub_langs": [],
+            },
+        ],
+        "mapping": {"title_1": "Bonus", "title_2": "Trailer"},
+        "confidence": 0.55,
+        "sources": base_sources(),
+    }
+    meta = validator.validate_payload(payload)
+    assert meta.content_type == "autre"
+    assert len(meta.items) == 2
+
+
+def test_validate_autre_reject_low_confidence() -> None:
+    payload = {
+        "disc_uid": "DISC006",
+        "content_type": "autre",
+        "movie_title": None,
+        "series_title": None,
+        "language": "fr",
+        "year": None,
+        "items": [
+            {
+                "type": "bonus",
+                "title_index": 1,
+                "runtime_seconds": 900,
+                "audio_langs": [],
+                "sub_langs": [],
+            }
+        ],
+        "mapping": {"title_1": "Bonus"},
+        "confidence": 0.4,
+        "sources": base_sources(),
+    }
+    with pytest.raises(validator.ValidationError):
+        validator.validate_payload(payload)


### PR DESCRIPTION
## Summary
- add a dedicated Pydantic validator enforcing conditional rules for film, serie and autre metadata
- plug the validator into the scanner and MKV build consumer, improve naming sanitisation and regenerate documentation
- add unit tests for the validator plus an integration check exercising mkv_build_consumer gating

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ec92e314b083318512d43c491ad341