### PR TITLE
Phase 3: export MKV vers Jellyfin

### DIFF
--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -131,7 +131,7 @@ Commande MakeMKV utilisée :
 makemkvcon -r --progress=-stdout mkv "file:$DEST/<DISC_UID>/$RAW_BACKUP_DIR" title:<index> "$DEST/<DISC_UID>/mkv" ${MAKEMKV_MKV_OPTS}
 ```
 
-Après création, le fichier généré (`title_tXX.mkv`) est renommé selon les templates (`OUTPUT_NAMING_TEMPLATE_*`). Les sorties existantes (>0 octet) sont ignorées pour garantir l'idempotence. Si `WRITE_NFO=1`, un `.nfo` minimal est créé (film ou `episodedetails`).
+Après création, le fichier généré (`title_tXX.mkv`) est renommé selon les templates (`OUTPUT_NAMING_TEMPLATE_*`). Les sorties existantes (>0 octet) sont ignorées pour garantir l'idempotence. Si `WRITE_NFO=1`, des `.nfo` Jellyfin/Kodi complets sont produits et l'ensemble `.mkv`/`.nfo` est exporté vers les bibliothèques Jellyfin (films, séries, bonus/specials) suivant la méthode (`copy`/`move`/`ln`).
 
 La fin du script affiche un récapitulatif (nombre de fichiers générés/ignorés). Si la validation échoue ou si MakeMKV retourne une erreur, le job est renommé en `.err` et aucun MKV n'est produit.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,7 +6,7 @@ Pipeline complet « Backup → OCR/IA → MKV » pour archiver des DVD vidéo en
 
 1. **Backup décrypté (Phase 1)** : `bin/do_backup.sh` lance `makemkvcon backup --decrypt` pour créer une copie complète du DVD (menus inclus) dans `raw/VIDEO_TS_BACKUP/`. La commande calcule un `disc_uid`, écrit `tech/fingerprint.json` ainsi que `tech/structure.lsdvd.yml`, puis enfile automatiquement la Phase 2.
 2. **Analyse menus + IA (Phase 2)** : `scan_consumer.sh` consomme les jobs de scan, extrait les menus `.VOB` via ffmpeg, exécute Tesseract, agrège les heuristiques et interroge un LLM local (Qwen2.5-14B via Ollama par défaut) pour produire `meta/metadata_ia.json` conforme au schéma imposé.
-3. **Build MKV (Phase 3)** : `mkv_build_consumer.sh` ne traite que les disques dont la métadonnée a été validée. Pour chaque titre, il appelle `makemkvcon mkv file:... title:X`, renomme les fichiers selon les templates, écrit optionnellement des sidecars `.nfo` et affiche un récapitulatif.
+3. **Build MKV (Phase 3)** : `mkv_build_consumer.sh` ne traite que les disques dont la métadonnée a été validée. Pour chaque titre, il appelle `makemkvcon mkv file:... title:X`, renomme les fichiers, génère des NFO Jellyfin/Kodi et exporte automatiquement les couples `.mkv`/`.nfo` vers les bibliothèques Jellyfin configurées (films, séries, bonus compris).
 
 Les scripts s'appuient sur `/etc/dvdarchiver.conf` (copié depuis `etc/dvdarchiver.conf.sample`) pour éviter tout chemin en dur. Toutes les étapes sont relançables sans effets de bord.
 
@@ -91,8 +91,9 @@ Voir `etc/dvdarchiver.conf.sample` pour la liste complète :
 
 - `MENU_SCENE_MODE`, `MENU_PREPROC_FILTERS` pour contrôler l'extraction de frames.
 - `LLM_*` pour sélectionner le fournisseur et le modèle (Ollama par défaut).
-- `OUTPUT_NAMING_TEMPLATE_*` pour personnaliser le nom des MKV.
-- `WRITE_NFO=1` pour générer des sidecars Jellyfin/Kodi.
+- `OUTPUT_NAMING_TEMPLATE_*` pour personnaliser les noms déposés dans `mkv/`.
+- Bloc **Export Jellyfin** (`EXPORT_ENABLE`, `EXPORT_METHOD`, `EXPORT_MOVIES_DIR`, `EXPORT_SERIES_DIR`, `EXPORT_MOVIE_EXTRAS_SUBDIR`, `EXPORT_SERIES_SPECIALS_SEASON`, `NFO_LANGUAGE_DEFAULT`, `SANITIZE_MAXLEN`) pour piloter l'export automatique (copy/move/ln) et la sanitation des chemins.
+- `WRITE_NFO=1` pour produire les `.nfo` locaux **et** exportés.
 
 ## Dépannage
 

--- a/dvd-archiver/bin/mkv_build_consumer.sh
+++ b/dvd-archiver/bin/mkv_build_consumer.sh
@@ -21,6 +21,14 @@ OUTPUT_NAMING_TEMPLATE_BONUS="${OUTPUT_NAMING_TEMPLATE_BONUS:-{title} - Bonus - 
 WRITE_NFO="${WRITE_NFO:-1}"
 MKVMERGE_BIN="${MKVMERGE_BIN:-mkvmerge}"
 TMP_DIR="${TMP_DIR:-/var/tmp/dvdarchiver}"
+EXPORT_ENABLE="${EXPORT_ENABLE:-1}"
+EXPORT_METHOD="${EXPORT_METHOD:-copy}"
+EXPORT_MOVIES_DIR="${EXPORT_MOVIES_DIR:-/mnt/nas/media/Library/Movies}"
+EXPORT_SERIES_DIR="${EXPORT_SERIES_DIR:-/mnt/nas/media/Library/Series}"
+EXPORT_MOVIE_EXTRAS_SUBDIR="${EXPORT_MOVIE_EXTRAS_SUBDIR:-extras}"
+EXPORT_SERIES_SPECIALS_SEASON="${EXPORT_SERIES_SPECIALS_SEASON:-0}"
+NFO_LANGUAGE_DEFAULT="${NFO_LANGUAGE_DEFAULT:-unknown}"
+SANITIZE_MAXLEN="${SANITIZE_MAXLEN:-180}"
 
 log() { printf '[mkv_consumer] %s\n' "$*"; }
 
@@ -33,6 +41,14 @@ run_builder() {
   OUTPUT_NAMING_TEMPLATE_SHOW="$OUTPUT_NAMING_TEMPLATE_SHOW" \
   OUTPUT_NAMING_TEMPLATE_BONUS="$OUTPUT_NAMING_TEMPLATE_BONUS" \
   WRITE_NFO="$WRITE_NFO" \
+  EXPORT_ENABLE="$EXPORT_ENABLE" \
+  EXPORT_METHOD="$EXPORT_METHOD" \
+  EXPORT_MOVIES_DIR="$EXPORT_MOVIES_DIR" \
+  EXPORT_SERIES_DIR="$EXPORT_SERIES_DIR" \
+  EXPORT_MOVIE_EXTRAS_SUBDIR="$EXPORT_MOVIE_EXTRAS_SUBDIR" \
+  EXPORT_SERIES_SPECIALS_SEASON="$EXPORT_SERIES_SPECIALS_SEASON" \
+  NFO_LANGUAGE_DEFAULT="$NFO_LANGUAGE_DEFAULT" \
+  SANITIZE_MAXLEN="$SANITIZE_MAXLEN" \
   MAKEMKV_BIN="$MAKEMKV_BIN" \
   MAKEMKV_MKV_OPTS="$MAKEMKV_MKV_OPTS" \
   SCAN_MODULE_DIR="${SCAN_MODULE_DIR:-${SCRIPT_DIR}/scan}" \
@@ -41,6 +57,7 @@ from __future__ import annotations
 import json
 import os
 import shlex
+import shutil
 import subprocess
 import sys
 from pathlib import Path
@@ -72,16 +89,21 @@ except RuntimeError as exc:  # pragma: no cover - dépendance manquante
     print(f"Validation indisponible: {exc}", file=sys.stderr)
     sys.exit(20)
 
+try:
+    from nfo_writer import (  # type: ignore
+        episode_nfo,
+        movie_nfo,
+        sanitize as sanitize_filename,
+        tvshow_nfo,
+        write_text as write_nfo_text,
+    )
+except ModuleNotFoundError as exc:
+    print(f"Module nfo_writer introuvable: {exc}", file=sys.stderr)
+    sys.exit(21)
 
-def sanitize(value: object, *, fallback: str = "Sans titre") -> str:
+
+def normalize_text(value: object, fallback: str) -> str:
     text = str(value or "").strip()
-    if not text:
-        text = fallback
-    forbidden = '<>:"/\\|?*'
-    for char in forbidden:
-        text = text.replace(char, "-")
-    text = text.replace("\n", " ").replace("\r", " ")
-    text = " ".join(text.split())
     return text or fallback
 
 
@@ -90,46 +112,219 @@ def apply_template(template: str, **values: object) -> str:
     result = result.replace("()", "").replace("( )", "")
     while "  " in result:
         result = result.replace("  ", " ")
+    result = result.strip()
+    result = result.rstrip("-")
+    result = result.replace(" - .", " .")
+    for ext in (".mkv", ".nfo"):
+        suffix = f" {ext}"
+        if result.endswith(suffix):
+            result = result[: -len(suffix)] + ext
     return result.strip()
 
 
-def xml_escape(text: str) -> str:
-    return (
-        text.replace("&", "&amp;")
-        .replace("<", "&lt;")
-        .replace(">", "&gt;")
-        .replace('"', "&quot;")
-        .replace("'", "&apos;")
-    )
+def ensure_extension(name: str, extension: str, maxlen: int) -> str:
+    candidate = name
+    if extension and not candidate.lower().endswith(extension.lower()):
+        candidate = f"{candidate}{extension}"
+    candidate = sanitize_filename(candidate, maxlen)
+    if extension and not candidate.lower().endswith(extension.lower()):
+        candidate = sanitize_filename(f"{candidate}{extension}", maxlen)
+    return candidate
 
 
-def write_nfo_file(final_path: Path, item, metadata, title_text: str, language: str) -> None:
-    nfo_path = final_path.with_suffix(".nfo")
-    if nfo_path.exists() and nfo_path.stat().st_size > 0:
+def minutes_from_seconds(seconds: int) -> int:
+    return max(1, int(round(seconds / 60)))
+
+
+def int_from_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:  # pragma: no cover - configuration invalide
+        raise RuntimeError(f"Valeur invalide pour {name}: {raw}") from exc
+
+
+def already_present(path: Path) -> bool:
+    if path.exists() or path.is_symlink():
+        try:
+            return path.stat().st_size > 0
+        except FileNotFoundError:
+            return False
+    return False
+
+
+def transfer_file(src: Path, dest: Path, method: str) -> None:
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    if dest.exists() or dest.is_symlink():
+        dest.unlink()
+    if method == "copy":
+        shutil.copy2(src, dest)
+    elif method == "move":
+        shutil.move(str(src), str(dest))
+    elif method == "hardlink":
+        os.link(src, dest)
+    elif method == "symlink":
+        dest.symlink_to(src.resolve())
+    else:  # pragma: no cover - méthode prévalidée en amont
+        raise ValueError(method)
+
+
+def write_sidecar(path: Path, content: str) -> bool:
+    if already_present(path):
+        return False
+    write_nfo_text(path, content)
+    return True
+
+
+def export_movie_items(
+    tasks: list[dict[str, object]],
+    export_dir: Path,
+    extras_subdir: str,
+    method: str,
+    disc_uid: str,
+    language: str,
+    year: int | None,
+    write_nfo_flag: bool,
+    sanitize_maxlen: int,
+) -> None:
+    main_task = next((task for task in tasks if task.get("kind") == "movie_main"), None)
+    if not main_task:
         return
-    if item.type == "episode":
-        content = (
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            "<episodedetails>\n"
-            f"  <title>{xml_escape(title_text)}</title>\n"
-            f"  <season>{int(item.season or 0)}</season>\n"
-            f"  <episode>{int(item.episode or 0)}</episode>\n"
-            "  <plot></plot>\n"
-            f"  <language>{xml_escape(language)}</language>\n"
-            "</episodedetails>\n"
-        )
+
+    movie_title_raw = str(main_task["movie_title_raw"])
+    folder_base = f"{movie_title_raw} ({year})" if year else movie_title_raw
+    folder_name = sanitize_filename(folder_base, sanitize_maxlen)
+    movie_dir = export_dir / folder_name
+    movie_dir.mkdir(parents=True, exist_ok=True)
+
+    main_dest_name = ensure_extension(sanitize_filename(folder_base, sanitize_maxlen), ".mkv", sanitize_maxlen)
+    main_dest = movie_dir / main_dest_name
+    source_path = Path(main_task["source"])
+    if already_present(main_dest):
+        print(f"Export: déjà présent -> {main_dest}")
     else:
-        year_value = metadata.year or ""
-        content = (
-            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
-            "<movie>\n"
-            f"  <title>{xml_escape(title_text)}</title>\n"
-            f"  <year>{xml_escape(str(year_value))}</year>\n"
-            "  <plot></plot>\n"
-            f"  <language>{xml_escape(language)}</language>\n"
-            "</movie>\n"
+        transfer_file(source_path, main_dest, method)
+        print(f"Export: {method} -> {main_dest}")
+
+    if write_nfo_flag:
+        nfo_content = movie_nfo(
+            disc_uid,
+            movie_title_raw,
+            year,
+            int(main_task.get("runtime", 0)),
+            language,
         )
-    nfo_path.write_text(content, encoding="utf-8")
+        nfo_path = main_dest.with_suffix(".nfo")
+        if write_sidecar(nfo_path, nfo_content):
+            print(f"Export NFO: écrit -> {nfo_path}")
+        else:
+            print(f"Export NFO: déjà présent -> {nfo_path}")
+
+    extras_dir = movie_dir
+    if extras_subdir:
+        extras_dir = movie_dir / extras_subdir
+        extras_dir.mkdir(parents=True, exist_ok=True)
+
+    for task in tasks:
+        if task.get("kind") != "movie_bonus":
+            continue
+        label_raw = str(task["label_raw"])
+        featurette_base = f"{movie_title_raw} - Featurette - {label_raw}"
+        featurette_name = ensure_extension(
+            sanitize_filename(featurette_base, sanitize_maxlen),
+            ".mkv",
+            sanitize_maxlen,
+        )
+        dest = extras_dir / featurette_name
+        source_path = Path(task["source"])
+        if already_present(dest):
+            print(f"Export: déjà présent -> {dest}")
+            continue
+        transfer_file(source_path, dest, method)
+        print(f"Export: {method} -> {dest}")
+        if write_nfo_flag:
+            content = movie_nfo(
+                disc_uid,
+                featurette_base,
+                year,
+                int(task.get("runtime", 0)),
+                language,
+            )
+            nfo_path = dest.with_suffix(".nfo")
+            if write_sidecar(nfo_path, content):
+                print(f"Export NFO: écrit -> {nfo_path}")
+            else:
+                print(f"Export NFO: déjà présent -> {nfo_path}")
+
+
+def export_series_items(
+    tasks: list[dict[str, object]],
+    export_dir: Path,
+    method: str,
+    disc_uid: str,
+    language: str,
+    premiered_year: int | None,
+    write_nfo_flag: bool,
+    sanitize_maxlen: int,
+) -> None:
+    entries = [task for task in tasks if task.get("kind") in {"series_episode", "series_special"}]
+    if not entries:
+        return
+
+    first = entries[0]
+    series_title_raw = str(first["series_title_raw"])
+    series_title_clean = str(first.get("series_title_clean") or sanitize_filename(series_title_raw, sanitize_maxlen))
+    show_dir = export_dir / series_title_clean
+    show_dir.mkdir(parents=True, exist_ok=True)
+
+    if write_nfo_flag:
+        tvshow_path = show_dir / "tvshow.nfo"
+        tvshow_content = tvshow_nfo(disc_uid, series_title_raw, language, premiered_year)
+        if write_sidecar(tvshow_path, tvshow_content):
+            print(f"Export NFO: écrit -> {tvshow_path}")
+        else:
+            print(f"Export NFO: déjà présent -> {tvshow_path}")
+
+    for entry in entries:
+        season = int(entry["season"])
+        episode = int(entry["episode"])
+        episode_component = str(entry.get("episode_title_component") or "")
+        episode_title_raw = str(entry.get("episode_title_raw"))
+        series_component = str(entry.get("series_title_clean") or series_title_clean)
+        base_name = f"{series_component} - S{season:02d}E{episode:02d}"
+        if episode_component:
+            base_name += f" - {episode_component}"
+        filename = ensure_extension(
+            sanitize_filename(base_name, sanitize_maxlen),
+            ".mkv",
+            sanitize_maxlen,
+        )
+        season_dir = show_dir / f"Season {season:02d}"
+        season_dir.mkdir(parents=True, exist_ok=True)
+        dest = season_dir / filename
+        source_path = Path(entry["source"])
+        if already_present(dest):
+            print(f"Export: déjà présent -> {dest}")
+            continue
+        transfer_file(source_path, dest, method)
+        print(f"Export: {method} -> {dest}")
+        if write_nfo_flag:
+            content = episode_nfo(
+                disc_uid,
+                series_title_raw,
+                season,
+                episode,
+                episode_title_raw,
+                int(entry.get("runtime", 0)),
+                language,
+            )
+            nfo_path = dest.with_suffix(".nfo")
+            if write_sidecar(nfo_path, content):
+                print(f"Export NFO: écrit -> {nfo_path}")
+            else:
+                print(f"Export NFO: déjà présent -> {nfo_path}")
 
 
 def main() -> int:
@@ -155,6 +350,27 @@ def main() -> int:
             print(f"  - {path}: {error.get('msg')}", file=sys.stderr)
         return 4
 
+    try:
+        sanitize_maxlen = int_from_env("SANITIZE_MAXLEN", 180)
+        specials_season = int_from_env("EXPORT_SERIES_SPECIALS_SEASON", 0)
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 5
+
+    export_enable = os.environ.get("EXPORT_ENABLE", "1") == "1"
+    export_method = os.environ.get("EXPORT_METHOD", "copy").strip().lower()
+    allowed_methods = {"copy", "move", "hardlink", "symlink"}
+    if export_method not in allowed_methods:
+        print(f"Méthode d'export invalide: {export_method}", file=sys.stderr)
+        return 6
+
+    export_movies_dir = Path(os.environ.get("EXPORT_MOVIES_DIR", "/mnt/nas/media/Library/Movies"))
+    export_series_dir = Path(os.environ.get("EXPORT_SERIES_DIR", "/mnt/nas/media/Library/Series"))
+    extras_subdir_raw = os.environ.get("EXPORT_MOVIE_EXTRAS_SUBDIR", "extras").strip()
+    extras_subdir = sanitize_filename(extras_subdir_raw, sanitize_maxlen) if extras_subdir_raw else ""
+    nfo_language_default = os.environ.get("NFO_LANGUAGE_DEFAULT", "unknown")
+    write_nfo = os.environ.get("WRITE_NFO", "1") == "1"
+
     raw_rel = os.environ.get("RAW_BACKUP_DIR", "raw/VIDEO_TS_BACKUP")
     backup_root = disc_dir / raw_rel
     movie_template = os.environ.get("OUTPUT_NAMING_TEMPLATE_MOVIE", "{title} ({year}).mkv")
@@ -163,7 +379,6 @@ def main() -> int:
         "{series_title} - S{season:02d}E{episode:02d} - {episode_title}.mkv",
     )
     bonus_template = os.environ.get("OUTPUT_NAMING_TEMPLATE_BONUS", "{title} - Bonus - {label}.mkv")
-    write_nfo = os.environ.get("WRITE_NFO", "1") == "1"
     makemkv_bin = os.environ.get("MAKEMKV_BIN", "makemkvcon")
     makemkv_opts = shlex.split(os.environ.get("MAKEMKV_MKV_OPTS", ""))
 
@@ -171,62 +386,147 @@ def main() -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     mapping = metadata.mapping
-    language = str(metadata.language)
+    language = normalize_text(metadata.language, nfo_language_default)
+    disc_uid = str(metadata.disc_uid)
+    content_type = str(metadata.content_type)
+    year_value = metadata.year
+
+    movie_title_raw = ""
+    movie_title_clean = ""
+    if content_type == "film":
+        movie_title_raw = normalize_text(metadata.movie_title, "")
+        if not movie_title_raw:
+            mains = [item for item in metadata.items if item.type == "main"]
+            if mains:
+                first_main = mains[0]
+                map_key = f"title_{int(first_main.title_index)}"
+                movie_title_raw = normalize_text(mapping.get(map_key), f"Titre {int(first_main.title_index)}")
+        if not movie_title_raw:
+            movie_title_raw = "Film"
+        movie_title_clean = sanitize_filename(movie_title_raw, sanitize_maxlen)
+
+    series_title_raw = normalize_text(metadata.series_title, "Série") if metadata.series_title else ""
+    series_title_clean = sanitize_filename(series_title_raw, sanitize_maxlen) if series_title_raw else ""
 
     generated: list[str] = []
     skipped: list[str] = []
+    export_tasks: list[dict[str, object]] = []
+    specials_counter = 0
 
     for item in metadata.items:
         title_index = int(item.title_index)
         key = f"title_{title_index}"
-        label = sanitize(item.label, fallback=f"Title {title_index}")
+        label_raw = normalize_text(item.label, f"Title {title_index}")
+        label_clean = sanitize_filename(label_raw, sanitize_maxlen)
+        runtime_minutes = minutes_from_seconds(int(item.runtime_seconds))
+        export_kind = None
+        export_payload: dict[str, object] = {}
 
         if item.type == "main":
-            base_title = sanitize(
-                metadata.movie_title
-                or mapping.get(key)
-                or label
-                or f"Titre {title_index}",
-                fallback=f"Titre {title_index}",
+            base_title_raw = normalize_text(
+                metadata.movie_title or mapping.get(key) or label_raw,
+                f"Titre {title_index}",
             )
-            year = metadata.year or ""
-            filename = apply_template(movie_template, title=base_title, year=year or "")
-            if not metadata.year:
-                filename = filename.replace(" ()", "").replace("()", "").strip()
-            nfo_title = base_title
+            movie_title_raw = base_title_raw
+            movie_title_clean = sanitize_filename(base_title_raw, sanitize_maxlen)
+            filename_base = apply_template(
+                movie_template,
+                title=movie_title_clean,
+                year=year_value or "",
+            )
+            filename = ensure_extension(filename_base, ".mkv", sanitize_maxlen)
+            nfo_title = base_title_raw
+            export_kind = "movie_main" if content_type == "film" else None
+            export_payload = {
+                "movie_title_raw": movie_title_raw,
+                "movie_title_clean": movie_title_clean,
+                "runtime": runtime_minutes,
+            }
         elif item.type == "episode":
-            series_title = sanitize(
-                metadata.series_title or metadata.movie_title or "Série",
-                fallback="Série",
-            )
+            if not series_title_raw:
+                series_title_raw = normalize_text(metadata.series_title or metadata.movie_title, "Série")
+                series_title_clean = sanitize_filename(series_title_raw, sanitize_maxlen)
             season = int(item.season or 1)
-            episode = int(item.episode or title_index)
-            episode_title = sanitize(
-                item.episode_title or label or f"Episode {episode}",
-                fallback=f"Episode {episode}",
-            )
-            filename = apply_template(
+            episode_num = int(item.episode or title_index)
+            raw_ep_title = str(item.episode_title or "").strip()
+            if raw_ep_title:
+                episode_component = sanitize_filename(normalize_text(raw_ep_title, f"Episode {episode_num}"), sanitize_maxlen)
+                nfo_title = normalize_text(raw_ep_title, f"Episode {episode_num}")
+            else:
+                episode_component = ""
+                nfo_title = normalize_text(label_raw, f"Episode {episode_num}")
+            filename_base = apply_template(
                 show_template,
-                series_title=series_title,
+                series_title=series_title_clean,
                 season=season,
-                episode=episode,
-                episode_title=episode_title,
+                episode=episode_num,
+                episode_title=episode_component,
             )
-            nfo_title = episode_title
+            filename = ensure_extension(filename_base, ".mkv", sanitize_maxlen)
+            export_kind = "series_episode" if content_type == "serie" else None
+            export_payload = {
+                "series_title_raw": series_title_raw,
+                "series_title_clean": series_title_clean,
+                "season": season,
+                "episode": episode_num,
+                "episode_title_raw": nfo_title,
+                "episode_title_component": episode_component,
+                "runtime": runtime_minutes,
+            }
         else:
-            base_title = sanitize(
-                metadata.movie_title or metadata.series_title or label or "Bonus",
-                fallback="Bonus",
-            )
-            filename = apply_template(
-                bonus_template,
-                title=base_title,
-                label=label or f"Title {title_index}",
-            )
-            nfo_title = label or base_title
+            if content_type == "film":
+                filename_base = apply_template(
+                    bonus_template,
+                    title=movie_title_clean or sanitize_filename(label_raw, sanitize_maxlen),
+                    label=label_clean,
+                )
+                filename = ensure_extension(filename_base, ".mkv", sanitize_maxlen)
+                nfo_title = f"{movie_title_raw} - Featurette - {label_raw}"
+                export_kind = "movie_bonus"
+                export_payload = {
+                    "movie_title_raw": movie_title_raw,
+                    "movie_title_clean": movie_title_clean,
+                    "label_raw": label_raw,
+                    "label_clean": label_clean,
+                    "runtime": runtime_minutes,
+                }
+            elif content_type == "serie":
+                if not series_title_raw:
+                    series_title_raw = normalize_text(metadata.series_title, "Série")
+                    series_title_clean = sanitize_filename(series_title_raw, sanitize_maxlen)
+                specials_counter += 1
+                season = specials_season
+                episode_num = int(item.episode or specials_counter)
+                label_display = normalize_text(label_raw, f"Bonus {episode_num}")
+                label_component = sanitize_filename(label_display, sanitize_maxlen)
+                filename_base = apply_template(
+                    show_template,
+                    series_title=series_title_clean,
+                    season=season,
+                    episode=episode_num,
+                    episode_title=label_component,
+                )
+                filename = ensure_extension(filename_base, ".mkv", sanitize_maxlen)
+                nfo_title = label_display
+                export_kind = "series_special"
+                export_payload = {
+                    "series_title_raw": series_title_raw,
+                    "series_title_clean": series_title_clean,
+                    "season": season,
+                    "episode": episode_num,
+                    "episode_title_raw": label_display,
+                    "episode_title_component": label_component,
+                    "runtime": runtime_minutes,
+                }
+            else:
+                filename_base = apply_template(
+                    bonus_template,
+                    title=sanitize_filename(label_raw, sanitize_maxlen),
+                    label=label_clean,
+                )
+                filename = ensure_extension(filename_base, ".mkv", sanitize_maxlen)
+                nfo_title = label_raw
 
-        if not filename.lower().endswith(".mkv"):
-            filename = f"{filename}.mkv"
         final_path = out_dir / filename
         if final_path.exists() and final_path.stat().st_size > 0:
             print(f"Skip (déjà présent): {final_path}")
@@ -254,8 +554,38 @@ def main() -> int:
         newest.rename(final_path)
         print(f"MKV généré: {final_path}")
         generated.append(str(final_path))
+
         if write_nfo:
-            write_nfo_file(final_path, item, metadata, nfo_title, language)
+            nfo_path = final_path.with_suffix(".nfo")
+            if item.type == "episode" or export_kind in {"series_episode", "series_special"}:
+                content = episode_nfo(
+                    disc_uid,
+                    series_title_raw or movie_title_raw,
+                    int(export_payload.get("season", item.season or 0)),
+                    int(export_payload.get("episode", item.episode or 0)),
+                    export_payload.get("episode_title_raw", nfo_title),
+                    runtime_minutes,
+                    language,
+                )
+            else:
+                content = movie_nfo(
+                    disc_uid,
+                    nfo_title,
+                    year_value,
+                    runtime_minutes,
+                    language,
+                )
+            if write_sidecar(nfo_path, content):
+                print(f"NFO écrit: {nfo_path}")
+            else:
+                print(f"NFO existant, ignoré: {nfo_path}")
+
+        if export_kind:
+            export_payload.update({
+                "kind": export_kind,
+                "source": final_path,
+            })
+            export_tasks.append(export_payload)
 
     print("--- Récapitulatif ---")
     print(f"Générés: {len(generated)}")
@@ -265,6 +595,40 @@ def main() -> int:
         print(f"Ignorés (déjà présents): {len(skipped)}")
         for path in skipped:
             print(f"  = {path}")
+
+    if export_enable:
+        try:
+            if content_type == "film":
+                export_movie_items(
+                    export_tasks,
+                    export_movies_dir,
+                    extras_subdir,
+                    export_method,
+                    disc_uid,
+                    language,
+                    year_value,
+                    write_nfo,
+                    sanitize_maxlen,
+                )
+            elif content_type == "serie":
+                export_series_items(
+                    export_tasks,
+                    export_series_dir,
+                    export_method,
+                    disc_uid,
+                    language,
+                    year_value,
+                    write_nfo,
+                    sanitize_maxlen,
+                )
+            else:
+                print(f"Export Jellyfin: type '{content_type}' ignoré")
+        except Exception as exc:  # pragma: no cover - dépendances externes
+            print(f"Erreur export Jellyfin: {exc}", file=sys.stderr)
+            return 7
+    else:
+        print("Export Jellyfin désactivé (EXPORT_ENABLE=0)")
+
     return 0
 
 

--- a/dvd-archiver/bin/scan/nfo_writer.py
+++ b/dvd-archiver/bin/scan/nfo_writer.py
@@ -1,0 +1,165 @@
+"""Outils pour générer des fichiers NFO compatibles Jellyfin/Kodi."""
+from __future__ import annotations
+
+from pathlib import Path
+import unicodedata
+
+FORBIDDEN_CHARS = set('/\0<>:"\\|?*')
+
+
+def _xml_escape(value: str) -> str:
+    """Échappe les caractères XML réservés."""
+    return (
+        value.replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+        .replace('"', "&quot;")
+        .replace("'", "&apos;")
+    )
+
+
+def sanitize(name: str, maxlen: int) -> str:
+    """Nettoie un nom de fichier/dossier en respectant la longueur maximale."""
+    text = unicodedata.normalize("NFC", (name or "").strip())
+    text = text.replace("\n", " ").replace("\r", " ")
+    cleaned = []
+    for char in text:
+        if char in FORBIDDEN_CHARS:
+            cleaned.append("-")
+        else:
+            cleaned.append(char)
+    text = "".join(cleaned)
+    text = " ".join(text.split())
+    text = text.rstrip(" .")
+    if not text:
+        text = "Sans titre"
+
+    if maxlen > 0 and len(text) > maxlen:
+        if "." in text:
+            base, dot, ext = text.rpartition(".")
+            if not base:
+                text = text[:maxlen]
+            else:
+                available = maxlen - len(dot + ext)
+                if available <= 0:
+                    text = (base + dot + ext)[:maxlen]
+                else:
+                    text = base[:available].rstrip(" .") + dot + ext
+        else:
+            text = text[:maxlen].rstrip(" .")
+        if not text:
+            text = "Sans titre"
+    return text
+
+
+def movie_nfo(
+    disc_uid: str,
+    movie_title: str,
+    year: int | None,
+    minutes: int,
+    language: str,
+    premiered: str | None = None,
+) -> str:
+    """Construit le contenu XML d'un fichier NFO film."""
+    year_text = str(year) if year else ""
+    premiered_text = premiered or ""
+    runtime_text = str(minutes) if minutes else ""
+    language_text = language or ""
+    title = _xml_escape(movie_title)
+    return "\n".join(
+        [
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<movie>",
+            f"  <title>{title}</title>",
+            f"  <originaltitle>{title}</originaltitle>",
+            f"  <sorttitle>{title}</sorttitle>",
+            f"  <year>{_xml_escape(year_text)}</year>",
+            f"  <premiered>{_xml_escape(premiered_text)}</premiered>",
+            f"  <uniqueid type=\"disc_uid\" default=\"true\">{_xml_escape(disc_uid)}</uniqueid>",
+            "  <plot></plot>",
+            "  <outline></outline>",
+            f"  <runtime>{_xml_escape(runtime_text)}</runtime>",
+            "  <mpaa></mpaa>",
+            "  <country></country>",
+            "  <studio></studio>",
+            "  <genre></genre>",
+            f"  <tag>{_xml_escape(language_text)}</tag>",
+            "</movie>",
+            "",
+        ]
+    )
+
+
+def tvshow_nfo(
+    disc_uid: str,
+    series_title: str,
+    language: str,
+    premiered_year: int | None = None,
+) -> str:
+    """Construit le contenu XML d'un fichier NFO série (tvshow.nfo)."""
+    premiered_text = str(premiered_year) if premiered_year else ""
+    title = _xml_escape(series_title)
+    return "\n".join(
+        [
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<tvshow>",
+            f"  <title>{title}</title>",
+            f"  <sorttitle>{title}</sorttitle>",
+            f"  <uniqueid type=\"disc_uid\" default=\"true\">{_xml_escape(disc_uid)}</uniqueid>",
+            "  <plot></plot>",
+            "  <mpaa></mpaa>",
+            "  <studio></studio>",
+            "  <genre></genre>",
+            f"  <premiered>{_xml_escape(premiered_text)}</premiered>",
+            f"  <tag>{_xml_escape(language)}</tag>",
+            "</tvshow>",
+            "",
+        ]
+    )
+
+
+def episode_nfo(
+    disc_uid: str,
+    series_title: str,
+    season: int,
+    episode: int,
+    ep_title: str,
+    minutes: int,
+    language: str,
+    aired: str | None = None,
+) -> str:
+    """Construit le contenu XML d'un fichier NFO épisode."""
+    aired_text = aired or ""
+    runtime_text = str(minutes) if minutes else ""
+    return "\n".join(
+        [
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
+            "<episodedetails>",
+            f"  <title>{_xml_escape(ep_title)}</title>",
+            f"  <season>{season}</season>",
+            f"  <episode>{episode}</episode>",
+            f"  <uniqueid type=\"disc_uid\" default=\"true\">{_xml_escape(disc_uid)}</uniqueid>",
+            f"  <aired>{_xml_escape(aired_text)}</aired>",
+            f"  <runtime>{_xml_escape(runtime_text)}</runtime>",
+            "  <plot></plot>",
+            f"  <showtitle>{_xml_escape(series_title)}</showtitle>",
+            f"  <language>{_xml_escape(language)}</language>",
+            "</episodedetails>",
+            "",
+        ]
+    )
+
+
+def write_text(path: Path, content: str) -> None:
+    """Écrit le contenu UTF-8 sur disque en s'assurant de la présence du dossier parent."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+__all__ = [
+    "sanitize",
+    "movie_nfo",
+    "tvshow_nfo",
+    "episode_nfo",
+    "write_text",
+]

--- a/dvd-archiver/etc/dvdarchiver.conf.sample
+++ b/dvd-archiver/etc/dvdarchiver.conf.sample
@@ -42,4 +42,14 @@ MAKEMKV_MKV_OPTS="--minlength=0"
 OUTPUT_NAMING_TEMPLATE_MOVIE="{title} ({year}).mkv"
 OUTPUT_NAMING_TEMPLATE_SHOW="{series_title} - S{season:02d}E{episode:02d} - {episode_title}.mkv"
 OUTPUT_NAMING_TEMPLATE_BONUS="{title} - Bonus - {label}.mkv"
+
+# --- Export Jellyfin ---
+EXPORT_ENABLE=1
+EXPORT_METHOD="copy"
+EXPORT_MOVIES_DIR="/mnt/nas/media/Library/Movies"
+EXPORT_SERIES_DIR="/mnt/nas/media/Library/Series"
+EXPORT_MOVIE_EXTRAS_SUBDIR="extras"
+EXPORT_SERIES_SPECIALS_SEASON=0
 WRITE_NFO=1
+NFO_LANGUAGE_DEFAULT="unknown"
+SANITIZE_MAXLEN=180


### PR DESCRIPTION
## Summary
- ajoute un module `nfo_writer` pour générer des NFO Jellyfin/Kodi normalisés
- étend `mkv_build_consumer.sh` afin de sanitiser les noms, produire les sidecars et exporter automatiquement films/séries (bonus inclus) selon la configuration Jellyfin
- documente la nouvelle configuration d’export et met à jour l’exemple `/etc/dvdarchiver.conf`

## Testing
- `python3 -m py_compile dvd-archiver/bin/scan/nfo_writer.py`


------
https://chatgpt.com/codex/tasks/task_b_68ec9806b1a483318f4040898dfc1c6f