### PR TITLE
Corrige l'indentation de la cible install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ PY_SOURCES := $(wildcard bin/scan/*.py)
 .PHONY: install uninstall lint fmt test test-shellcheck
 
 install:
-./install.sh --with-systemd --with-udev --prefix=$(PREFIX)
+	./install.sh --with-systemd --with-udev --prefix=$(PREFIX)
 
 uninstall:
 	rm -f $(addprefix $(BINDIR)/,$(notdir $(BIN_SCRIPTS)))


### PR DESCRIPTION
## Résumé
- corrige l'indentation de la commande de la cible `install` afin que la lecture du Makefile ne renvoie plus d'erreur "missing separator"

## Tests
- make uninstall

------
https://chatgpt.com/codex/tasks/task_b_68ed433044c88331ae93dcf4fd663875