### PR TITLE
Corrige la boucle de désinstallation

### DIFF
--- a/uninstall.sh
+++ b/uninstall.sh
@@ -77,7 +77,7 @@ remove_dir() {
 # Supprimer les binaires et bibliothèques installés
 for script in do_rip.sh queue_enqueue.sh queue_consumer.sh scan_enqueue.sh scan_consumer.sh; do
   remove_file "${BINDIR}/${script}"
-}
+done
 remove_dir "$SCAN_PY_DIR"
 remove_dir "$LIBDIR"
 


### PR DESCRIPTION
## Résumé
- corrige la boucle de suppression des scripts dans uninstall.sh pour éviter une erreur de syntaxe

## Tests
- bash -n uninstall.sh

------
https://chatgpt.com/codex/tasks/task_b_68ed4907e84883318a96163ae0378df9