### PR TITLE
Assure l'installation auto des dépendances manquantes

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -31,7 +31,7 @@ sudo make install            # ou sudo ./install.sh
 
 Le script d'installation :
 
-- vérifie la présence des dépendances (`makemkvcon`, `lsdvd`, `ffmpeg`, `tesseract`, `mkvmerge`, `python3`, `curl`...),
+- vérifie la présence des dépendances (`makemkvcon`, `lsdvd`, `ffmpeg`, `tesseract`, `isoinfo`/`genisoimage`, `mkvmerge`, `python3`, `curl`...) et installe automatiquement via APT celles qui sont disponibles (`lsdvd`, `ffmpeg`, `tesseract`, `genisoimage`, `mkvtoolnix`, `curl`, `python3`, `eject`),
 - installe Ollama si nécessaire puis tente `ollama pull qwen2.5:14b-instruct-q4_K_M`,
 - copie les scripts shell dans `/usr/local/bin/`, les modules Python dans `/usr/local/bin/scan/`,
 - crée `/etc/dvdarchiver.conf` si absent et prépare les répertoires (`DEST`, queues, logs),
@@ -72,7 +72,7 @@ $DEST/<DISC_UID>/
 
 ## Dépendances essentielles
 
-- **Phase 1** : `makemkvcon`, `lsdvd`, `eject`, `sha256sum`.
+- **Phase 1** : `makemkvcon`, `lsdvd`, `eject`, `isoinfo` (`genisoimage`), `sha256sum`.
 - **Phase 2** : `ffmpeg`, `tesseract-ocr`, `python3`, `requests` (pour Ollama), modèle LLM via Ollama.
 - **Phase 3** : `makemkvcon`, `mkvmerge` (fallback technique), `python3`.
 

--- a/install.sh
+++ b/install.sh
@@ -44,6 +44,18 @@ ensure_package() {
   fi
 }
 
+ensure_command() {
+  local bin="$1" pkg="${2:-$1}"
+  if command -v "$bin" >/dev/null 2>&1; then
+    return
+  fi
+  echo "Commande $bin absente, tentative d'installation via $pkg"
+  ensure_package "$pkg"
+  if ! command -v "$bin" >/dev/null 2>&1; then
+    echo "Avertissement: la commande $bin reste indisponible après l'installation de $pkg" >&2
+  fi
+}
+
 install_ollama() {
   if command -v ollama >/dev/null 2>&1; then
     return
@@ -104,8 +116,20 @@ SCAN_PY_DIR="${PREFIX}/bin/scan"
 
 install -d "$BINDIR" "$LIBDIR" "$SCAN_PY_DIR"
 
-for pkg in tesseract-ocr ffmpeg mkvtoolnix curl; do
-  ensure_package "$pkg"
+REQUIRED_COMMANDS=(
+  "tesseract:tesseract-ocr"
+  "ffmpeg:ffmpeg"
+  "mkvmerge:mkvtoolnix"
+  "curl:curl"
+  "lsdvd:lsdvd"
+  "isoinfo:genisoimage"
+  "eject:eject"
+  "python3:python3"
+)
+
+for spec in "${REQUIRED_COMMANDS[@]}"; do
+  IFS=':' read -r bin pkg <<<"$spec"
+  ensure_command "$bin" "$pkg"
 done
 
 install_ollama


### PR DESCRIPTION
## Résumé
- installe automatiquement via APT les binaires requis uniquement lorsqu'ils sont absents
- documente le comportement d'installation automatique des dépendances disponibles

## Tests
- bash -n install.sh

------
https://chatgpt.com/codex/tasks/task_b_68ed503e8c648331a02bd269355b5a9d