### PR TITLE
Corrige la récupération de l'empreinte disque

### DIFF
--- a/bin/do_rip.sh
+++ b/bin/do_rip.sh
@@ -60,8 +60,14 @@ main() {
     title="DVD_UNTITLED"
   fi
 
-  local sha_full
-  sha_full=$(disc_id "$title")
+  local sha_full disc_sha_short
+  if ! IFS=' ' read -r sha_full disc_sha_short < <(disc_id "$title"); then
+    log_err "Impossible de calculer l'empreinte du disque"
+    exit 31
+  fi
+  DISC_SHA_FULL="$sha_full"
+  DISC_SHA_SHORT="$disc_sha_short"
+  export DISC_SHA_FULL DISC_SHA_SHORT
   local dest_dir="$DEST/${DISC_SHA_SHORT}"
   mkdir -p "$dest_dir/mkv" "$dest_dir/tech" "$dest_dir/meta" "$dest_dir/raw"
 

--- a/bin/lib/hash.sh
+++ b/bin/lib/hash.sh
@@ -84,5 +84,5 @@ disc_id() {
     DISC_SHA_SHORT="$DISC_SHA_FULL"
   fi
   export DISC_SHA_SHORT
-  printf '%s\n' "$DISC_SHA_FULL"
+  printf '%s %s\n' "$DISC_SHA_FULL" "$DISC_SHA_SHORT"
 }


### PR DESCRIPTION
## Summary
- récupère correctement les valeurs DISC_SHA_FULL et DISC_SHA_SHORT lors du calcul de l'empreinte
- fait retourner à disc_id le hash complet et tronqué pour éviter les variables non initialisées

## Testing
- shellcheck bin/do_rip.sh bin/lib/hash.sh *(échec : commande indisponible dans l'environnement)*

------
https://chatgpt.com/codex/tasks/task_b_68ed523e2cc483318e59a4daf2399778