### PR TITLE
Remplacer do_rip par do_backup dans la file d'attente

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ ifeq ($(KEEP_MODEL),1)
 UNINSTALL_ARGS += --keep-model
 endif
 
-BIN_SCRIPTS := bin/do_rip.sh bin/queue_enqueue.sh bin/queue_consumer.sh bin/scan_enqueue.sh bin/scan_consumer.sh
+BIN_SCRIPTS := dvd-archiver/bin/do_backup.sh bin/queue_enqueue.sh bin/queue_consumer.sh bin/scan_enqueue.sh bin/scan_consumer.sh
 LIB_SCRIPTS := bin/lib/common.sh bin/lib/hash.sh bin/lib/techdump.sh
 ROOT_SCRIPTS := install.sh uninstall.sh
 SYSTEMD_UNITS := systemd/dvdarchiver-queue-consumer.service systemd/dvdarchiver-queue-consumer.path systemd/dvdarchiver-queue-consumer.timer \

--- a/bin/queue_consumer.sh
+++ b/bin/queue_consumer.sh
@@ -27,10 +27,45 @@ fi
 # shellcheck source=bin/lib/common.sh
 source "$LIB_DIR/common.sh"
 
-DO_RIP_BIN="${DO_RIP_BIN:-$SCRIPT_DIR/do_rip.sh}"
+DO_BACKUP_BIN="${DO_BACKUP_BIN:-}"
 
-if [[ ! -x "$DO_RIP_BIN" ]]; then
-  log_err "Script do_rip introuvable ou non exécutable: $DO_RIP_BIN"
+find_do_backup() {
+  if [[ -n "$DO_BACKUP_BIN" ]]; then
+    if command -v "$DO_BACKUP_BIN" >/dev/null 2>&1; then
+      DO_BACKUP_BIN="$(command -v "$DO_BACKUP_BIN")"
+      return 0
+    fi
+    if [[ -x "$DO_BACKUP_BIN" ]]; then
+      return 0
+    fi
+  fi
+
+  local candidate
+  if command -v do_backup.sh >/dev/null 2>&1; then
+    candidate="$(command -v do_backup.sh)"
+    if [[ -x "$candidate" ]]; then
+      DO_BACKUP_BIN="$candidate"
+      return 0
+    fi
+  fi
+
+  candidate="$SCRIPT_DIR/do_backup.sh"
+  if [[ -x "$candidate" ]]; then
+    DO_BACKUP_BIN="$candidate"
+    return 0
+  fi
+
+  candidate="$SCRIPT_DIR/../dvd-archiver/bin/do_backup.sh"
+  if [[ -x "$candidate" ]]; then
+    DO_BACKUP_BIN="$candidate"
+    return 0
+  fi
+
+  return 1
+}
+
+if ! find_do_backup; then
+  log_err "Script do_backup introuvable (utilisez DO_BACKUP_BIN pour préciser le chemin)"
   exit 51
 fi
 
@@ -45,7 +80,7 @@ process_job() {
   source "$job"
   local status_file
   status_file="${job%.job}"
-  if [[ "${ACTION:-}" != "RIP" ]]; then
+  if [[ "${ACTION:-}" != "BACKUP" ]]; then
     log_warn "Action inconnue (${ACTION:-}) pour $job"
     rm -f "${status_file}.skipped"
     mv "$job" "${status_file}.skipped"
@@ -53,7 +88,7 @@ process_job() {
   fi
   export DEVICE
   local exit_code=0
-  if "$DO_RIP_BIN"; then
+  if "$DO_BACKUP_BIN"; then
     exit_code=0
   else
     exit_code=$?

--- a/bin/queue_enqueue.sh
+++ b/bin/queue_enqueue.sh
@@ -41,7 +41,7 @@ main() {
   done
   cat >"$job_file" <<JOB
 DEVICE=${DEVICE}
-ACTION=RIP
+ACTION=BACKUP
 JOB_TS=${ts_now}
 JOB_ID=${rand}
 JOB

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -2,9 +2,9 @@
 
 - **Agent udev** : règle `99-dvdarchiver.rules` déclenche `queue_enqueue.sh` lors de l'insertion d'un disque.
 - **Queue Consumer (systemd)** : `dvdarchiver-queue-consumer.service` surveille la file et appelle `queue_consumer.sh`.
-- **Ripper** : `do_rip.sh` réalise le rip complet et génère `tech/` + `meta/` (vide) selon l'empreinte disque.
+- **Ripper** : `do_backup.sh` réalise le backup complet et génère `tech/` + `meta/` (vide) selon l'empreinte disque.
 - **Scanner IA (à venir)** : consommera `mkv/` et `tech/` pour écrire `meta/metadata_ia.json`.
 
 ```
-[udev] --(JOB)-> [QUEUE_DIR] --(path/timer)-> [queue_consumer.sh] --(exec)-> [do_rip.sh] --(artefacts)-> DEST
+[udev] --(JOB)-> [QUEUE_DIR] --(path/timer)-> [queue_consumer.sh] --(exec)-> [do_backup.sh] --(artefacts)-> DEST
 ```

--- a/docs/PIPELINE.md
+++ b/docs/PIPELINE.md
@@ -2,7 +2,7 @@
 
 ## Phase 1 – Backup complet décrypté
 
-- Script : `bin/do_backup.sh`.
+- Script : `do_backup.sh`.
 - Actions principales :
   - Vérification des dépendances (`makemkvcon`, `lsdvd`, `sha256sum`, `df`).
   - Lecture unique du DVD via `makemkvcon -r backup --decrypt disc:0 <DEST>/<DISC_UID>/raw/VIDEO_TS_BACKUP/`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ Pipeline complet « Backup → OCR/IA → MKV » pour archiver des DVD vidéo en
 
 ## Vue d'ensemble
 
-1. **Backup décrypté (Phase 1)** : `bin/do_backup.sh` lance `makemkvcon backup --decrypt` pour créer une copie complète du DVD (menus inclus) dans `raw/VIDEO_TS_BACKUP/`. La commande calcule un `disc_uid`, écrit `tech/fingerprint.json` ainsi que `tech/structure.lsdvd.yml`, puis enfile automatiquement la Phase 2.
+1. **Backup décrypté (Phase 1)** : `do_backup.sh` lance `makemkvcon backup --decrypt` pour créer une copie complète du DVD (menus inclus) dans `raw/VIDEO_TS_BACKUP/`. La commande calcule un `disc_uid`, écrit `tech/fingerprint.json` ainsi que `tech/structure.lsdvd.yml`, puis enfile automatiquement la Phase 2.
 2. **Analyse menus + IA (Phase 2)** : `scan_consumer.sh` consomme les jobs de scan, extrait les menus `.VOB` via ffmpeg, exécute Tesseract, agrège les heuristiques et interroge un LLM local (Qwen2.5-14B via Ollama par défaut) pour produire `meta/metadata_ia.json` conforme au schéma imposé.
 3. **Build MKV (Phase 3)** : `mkv_build_consumer.sh` ne traite que les disques dont la métadonnée a été validée. Pour chaque titre, il appelle `makemkvcon mkv file:... title:X`, renomme les fichiers, génère des NFO Jellyfin/Kodi et exporte automatiquement les couples `.mkv`/`.nfo` vers les bibliothèques Jellyfin configurées (films, séries, bonus compris).
 

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,15 @@ if command -v ollama >/dev/null 2>&1; then
   set -e
 fi
 
-for script in "$SCRIPT_DIR"/bin/do_rip.sh "$SCRIPT_DIR"/bin/queue_enqueue.sh "$SCRIPT_DIR"/bin/queue_consumer.sh "$SCRIPT_DIR"/bin/scan_enqueue.sh "$SCRIPT_DIR"/bin/scan_consumer.sh; do
+BIN_SCRIPTS=(
+  "$SCRIPT_DIR/dvd-archiver/bin/do_backup.sh"
+  "$SCRIPT_DIR/bin/queue_enqueue.sh"
+  "$SCRIPT_DIR/bin/queue_consumer.sh"
+  "$SCRIPT_DIR/bin/scan_enqueue.sh"
+  "$SCRIPT_DIR/bin/scan_consumer.sh"
+)
+
+for script in "${BIN_SCRIPTS[@]}"; do
   install -m 0755 "$script" "$BINDIR/$(basename "$script")"
   echo "Installé $BINDIR/$(basename "$script")"
 done

--- a/uninstall.sh
+++ b/uninstall.sh
@@ -75,7 +75,7 @@ remove_dir() {
 }
 
 # Supprimer les binaires et bibliothèques installés
-for script in do_rip.sh queue_enqueue.sh queue_consumer.sh scan_enqueue.sh scan_consumer.sh; do
+for script in do_backup.sh queue_enqueue.sh queue_consumer.sh scan_enqueue.sh scan_consumer.sh; do
   remove_file "${BINDIR}/${script}"
 done
 remove_dir "$SCAN_PY_DIR"


### PR DESCRIPTION
## Résumé
- remplacer l'action de la file d'attente pour exécuter do_backup.sh et détecter automatiquement le binaire
- installer/désinstaller do_backup.sh à la place de do_rip.sh et mettre la documentation à jour
- ajuster la configuration de build pour analyser le nouveau script avec shellcheck

## Tests
- `make test-shellcheck` *(shellcheck non disponible)*

------
https://chatgpt.com/codex/tasks/task_b_68ed59bb68d88331b427113cbee1ae7c