### PR TITLE
Aligner queue_consumer sur le pipeline do_backup

### DIFF
--- a/etc/dvdarchiver.conf.sample
+++ b/etc/dvdarchiver.conf.sample
@@ -16,6 +16,9 @@ LSDVD_BIN="lsdvd"
 EJECT_BIN="eject"
 MOUNT_OPTS="udf,iso9660,ro"
 MAKEMKV_OPTS="--minlength=0"
+DO_BACKUP_BIN="/usr/local/bin/do_backup.sh"
+# Optionnel : exécuter l'ancien rip MakeMKV (mkv) après le backup.
+LEGACY_RIP_BIN=""
 
 # --- Phase 1 : backup décrypté des menus ---
 KEEP_MENU_VOBS=1

--- a/install.sh
+++ b/install.sh
@@ -140,7 +140,7 @@ if command -v ollama >/dev/null 2>&1; then
   set -e
 fi
 
-for script in "$SCRIPT_DIR"/bin/do_rip.sh "$SCRIPT_DIR"/bin/queue_enqueue.sh "$SCRIPT_DIR"/bin/queue_consumer.sh "$SCRIPT_DIR"/bin/scan_enqueue.sh "$SCRIPT_DIR"/bin/scan_consumer.sh; do
+for script in "$SCRIPT_DIR"/dvd-archiver/bin/do_backup.sh "$SCRIPT_DIR"/bin/do_rip.sh "$SCRIPT_DIR"/bin/queue_enqueue.sh "$SCRIPT_DIR"/bin/queue_consumer.sh "$SCRIPT_DIR"/bin/scan_enqueue.sh "$SCRIPT_DIR"/bin/scan_consumer.sh; do
   install -m 0755 "$script" "$BINDIR/$(basename "$script")"
   echo "Installé $BINDIR/$(basename "$script")"
 done


### PR DESCRIPTION
## Summary
- mettre à jour queue_consumer.sh pour exécuter do_backup par défaut et proposer do_rip.sh en option post-backup via la configuration
- ajouter les variables DO_BACKUP_BIN et LEGACY_RIP_BIN dans l'exemple de configuration
- installer automatiquement do_backup.sh lors de l'exécution d'install.sh

## Testing
- shellcheck bin/queue_consumer.sh *(échoue: shellcheck absent)*

------
https://chatgpt.com/codex/tasks/task_b_68ed5e5ddcdc833186dc8833823625e5