### PR TITLE
Généralise le mode debug dans le pipeline

### DIFF
--- a/bin/lib/common.sh
+++ b/bin/lib/common.sh
@@ -52,10 +52,14 @@ cleanup_artifact() {
     fi
     log_info "$msg"
   else
+    local rm_failed=0
     if [[ -d "$path" && ! -L "$path" ]]; then
-      rm -rf "$path"
+      rm -rf "$path" || rm_failed=1
     else
-      rm -f "$path"
+      rm -f "$path" || rm_failed=1
+    fi
+    if (( rm_failed )); then
+      log_warn "Impossible de supprimer $path, artefact conservé pour diagnostic"
     fi
   fi
 }

--- a/bin/lib/common.sh
+++ b/bin/lib/common.sh
@@ -31,8 +31,34 @@ MIN_FREE_GB="${MIN_FREE_GB:-10}"
 EJECT_ON_DONE="${EJECT_ON_DONE:-1}"
 ALLOW_ISO_DUMP="${ALLOW_ISO_DUMP:-0}"
 ARCHIVE_LAYOUT_VERSION="${ARCHIVE_LAYOUT_VERSION:-1.0}"
+DEBUG_MODE="${DEBUG_MODE:-0}"
 
 LOG_TAG="dvdarchiver"
+
+debug_enabled() {
+  [[ "$DEBUG_MODE" == "1" ]]
+}
+
+cleanup_artifact() {
+  local path="$1"
+  local reason="${2:-}"
+  if [[ ! -e "$path" && ! -L "$path" ]]; then
+    return
+  fi
+  if debug_enabled; then
+    local msg="Mode debug actif : conservation de $path"
+    if [[ -n "$reason" ]]; then
+      msg+=" (${reason})"
+    fi
+    log_info "$msg"
+  else
+    if [[ -d "$path" && ! -L "$path" ]]; then
+      rm -rf "$path"
+    else
+      rm -f "$path"
+    fi
+  fi
+}
 
 _ts_now() {
   date -u +"%Y-%m-%dT%H:%M:%SZ"

--- a/bin/lib/hash.sh
+++ b/bin/lib/hash.sh
@@ -35,7 +35,7 @@ disc_struct_hash() {
   else
     log_warn "Montage impossible pour calcul de hash structurel"
   fi
-  rmdir "$mount_point" 2>/dev/null || true
+  cleanup_artifact "$mount_point" "répertoire de montage temporaire"
   printf '%s' "$hash"
 }
 
@@ -61,7 +61,7 @@ disc_sector_hash() {
   printf '\n%s' "$title" >>"$tmpfile"
   local sector_hash
   sector_hash=$(sha256sum "$tmpfile" | awk '{print $1}')
-  rm -f "$tmpfile"
+  cleanup_artifact "$tmpfile" "dump secteurs (hash)"
   printf '%s' "$sector_hash"
 }
 

--- a/bin/lib/techdump.sh
+++ b/bin/lib/techdump.sh
@@ -32,7 +32,7 @@ dump_lsdvd_yaml() {
     log_warn "Échec lsdvd, voir $outfile.err"
     return 1
   fi
-  rm -f "$outfile.err"
+  cleanup_artifact "$outfile.err" "journal lsdvd"
   return 0
 }
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -96,6 +96,7 @@ Voir `etc/dvdarchiver.conf.sample` pour la liste complète :
 - `OUTPUT_NAMING_TEMPLATE_*` pour personnaliser les noms déposés dans `mkv/`.
 - Bloc **Export Jellyfin** (`EXPORT_ENABLE`, `EXPORT_METHOD`, `EXPORT_MOVIES_DIR`, `EXPORT_SERIES_DIR`, `EXPORT_MOVIE_EXTRAS_SUBDIR`, `EXPORT_SERIES_SPECIALS_SEASON`, `NFO_LANGUAGE_DEFAULT`, `SANITIZE_MAXLEN`) pour piloter l'export automatique (copy/move/ln) et la sanitation des chemins.
 - `WRITE_NFO=1` pour produire les `.nfo` locaux **et** exportés.
+- `DEBUG_MODE=1` pour conserver tous les artefacts temporaires le long du pipeline (analyse, backup, scans) et faciliter le diagnostic.
 
 ## Dépannage
 

--- a/etc/dvdarchiver.conf.sample
+++ b/etc/dvdarchiver.conf.sample
@@ -8,6 +8,10 @@ TMP_DIR="/var/tmp/dvdarchiver"
 SCAN_QUEUE_DIR="/var/spool/dvdarchiver-scan"
 SCAN_LOG_DIR="/var/log/dvdarchiver-scan"
 
+# --- Mode debug ---
+# Positionnez à 1 pour conserver l'ensemble des fichiers temporaires et journaux intermédiaires.
+DEBUG_MODE=0
+
 # --- Lecteur & outils de base ---
 DEVICE="/dev/sr0"
 MAKEMKV_BIN="makemkvcon"


### PR DESCRIPTION
## Summary
- ajoute l'option DEBUG_MODE dans la configuration et la documentation
- étend la conservation conditionnelle des artefacts temporaires à do_backup, hash et techdump
- fournit des helpers communs pour centraliser la logique debug sur l'ensemble du pipeline

## Testing
- bash -n dvd-archiver/bin/do_backup.sh
- bash -n bin/lib/common.sh
- bash -n bin/lib/hash.sh
- bash -n bin/lib/techdump.sh

------
https://chatgpt.com/codex/tasks/task_b_68ede24284b88331b825db97a5d68503